### PR TITLE
feat: add mal_id to anime entity

### DIFF
--- a/src/migrations/1749945600000-add_mal_id_to_anime.ts
+++ b/src/migrations/1749945600000-add_mal_id_to_anime.ts
@@ -1,0 +1,29 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addMalIdToAnime1749945600000 implements MigrationInterface {
+    name = 'addMalIdToAnime1749945600000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" ADD "mal_id" integer`);
+        await queryRunner.query(`CREATE INDEX "IDX_anime_mal_id" ON "anime" ("mal_id")`);
+
+        // Backfill mal_id from existing myanimelist_link records
+        await queryRunner.query(`
+            UPDATE "anime" a
+            SET "mal_id" = CAST(
+                substring(ml."link" from '/anime/([0-9]+)')
+                AS integer
+            )
+            FROM "myanimelist_link" ml
+            WHERE ml."anime_id" = a."id"
+            AND ml."link" ~ '/anime/[0-9]+'
+            AND a."mal_id" IS NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_anime_mal_id"`);
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "mal_id"`);
+    }
+
+}

--- a/src/modules/anime/anime.service.ts
+++ b/src/modules/anime/anime.service.ts
@@ -44,6 +44,12 @@ export class AnimeService {
       throw new Error('MyAnimeList URL is required for all anime entries')
     }
 
+    // Extract MAL ID from the URL (e.g., https://myanimelist.net/anime/52991/...)
+    const malIdMatch = myAnimeListUrl.match(/\/anime\/(\d+)/)
+    if (malIdMatch) {
+      animeData.mal_id = parseInt(malIdMatch[1], 10)
+    }
+
     // First check if a MyAnimeList link already exists for this URL
     const existingLink = await this.myanimelistlinkRepository.findOne({
       where: { link: myAnimeListUrl },

--- a/src/modules/anime/repository/anime.entity.ts
+++ b/src/modules/anime/repository/anime.entity.ts
@@ -20,6 +20,9 @@ export class Anime {
   @Column({ name: 'anidbid', nullable: true })
   anidbid: string
 
+  @Column({ name: 'mal_id', nullable: true, type: 'int' })
+  mal_id: number
+
   @Column({ name: 'type', enum: RECORD_TYPE, default: RECORD_TYPE.Anime })
   type: RECORD_TYPE
 

--- a/src/modules/anime/repository/interface.ts
+++ b/src/modules/anime/repository/interface.ts
@@ -2,6 +2,7 @@ export interface IAnime {
   id: string
 
   anidbid: string
+  mal_id: number
   type: RECORD_TYPE
   title_en: string
   title_jp: string


### PR DESCRIPTION
## Summary
- Add `mal_id` column to the PostgreSQL anime table
- Extract MAL ID from MyAnimeList URL during `upsertAnimeWithMyAnimeListLink`
- Migration backfills existing anime records from `myanimelist_link` table
- CDC automatically propagates `mal_id` in Kafka events for downstream consumers (anime-sync)

## Test plan
- [ ] Run migration and verify `mal_id` column exists on anime table
- [ ] Verify backfill populated `mal_id` for anime with existing myanimelist_link records
- [ ] Scrape a new anime and verify `mal_id` is set correctly
- [ ] Verify Kafka CDC events include the `mal_id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)