### PR TITLE
fix: make IAnime.mal_id optional (unblock build)

### DIFF
--- a/src/modules/anime/repository/interface.ts
+++ b/src/modules/anime/repository/interface.ts
@@ -2,7 +2,7 @@ export interface IAnime {
   id: string
 
   anidbid: string
-  mal_id: number
+  mal_id?: number
   type: RECORD_TYPE
   title_en: string
   title_jp: string


### PR DESCRIPTION
## Why

Merging #2 made `mal_id` a **required** field on the `IAnime` interface, but the mappers in `anime.repository.ts` construct `IAnime` object literals field-by-field and don't set it. That broke `yarn build` on `main` with 5× `TS2741: Property 'mal_id' is missing … but required in type 'IAnime'` (lines 14/49/82/134/169), failing the Docker Image CI push.

## Fix

Make `mal_id` optional (`mal_id?: number`) on `IAnime`. It's a nullable column, and the value is set explicitly on the write path (`anime.service.ts` parses it from the MAL URL before upsert), so the read-mappers omitting it is fine. One-line change; resolves all 5 errors without touching each mapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)