### PR TITLE
fix: add mal_id migration to root migrations/ dir

### DIFF
--- a/migrations/1749945600000-add_mal_id_to_anime.ts
+++ b/migrations/1749945600000-add_mal_id_to_anime.ts
@@ -1,0 +1,29 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addMalIdToAnime1749945600000 implements MigrationInterface {
+    name = 'addMalIdToAnime1749945600000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" ADD "mal_id" integer`);
+        await queryRunner.query(`CREATE INDEX "IDX_anime_mal_id" ON "anime" ("mal_id")`);
+
+        // Backfill mal_id from existing myanimelist_link records
+        await queryRunner.query(`
+            UPDATE "anime" a
+            SET "mal_id" = CAST(
+                substring(ml."link" from '/anime/([0-9]+)')
+                AS integer
+            )
+            FROM "myanimelist_link" ml
+            WHERE ml."anime_id" = a."id"
+            AND ml."link" ~ '/anime/[0-9]+'
+            AND a."mal_id" IS NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_anime_mal_id"`);
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "mal_id"`);
+    }
+
+}


### PR DESCRIPTION
## Why

`ormconfig.js` points TypeORM at **different migration directories depending on `ENV`**:

| ENV | migrations glob | cli.migrationsDir |
|---|---|---|
| `local` | `dist/migrations/*` (compiled from `src/migrations`) | `src/migrations` |
| non-local | `migrations/*` | `migrations` (repo root) |

The `mal_id` migration (`1749945600000-add_mal_id_to_anime`) only existed in `src/migrations/`, so it's picked up under `ENV=local` (after a build) but **not** under the non-local path, which reads the root `./migrations/` folder. This copies the same migration into `./migrations/` so it runs whichever `ENV` is used.

Identical content to the `src/migrations/` copy; TypeORM tracks by the `1749945600000` timestamp, so there's no double-apply risk (only one folder is loaded per `ENV`).

> Note: the repo has a split-brain migrations setup (two folders, each visible under a different `ENV`). Worth consolidating to one later, but this unblocks the `mal_id` backfill now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)