### PR TITLE
fix: cast uuid to text in mal_id backfill join

### DIFF
--- a/migrations/1749945600000-add_mal_id_to_anime.ts
+++ b/migrations/1749945600000-add_mal_id_to_anime.ts
@@ -15,7 +15,7 @@ export class addMalIdToAnime1749945600000 implements MigrationInterface {
                 AS integer
             )
             FROM "myanimelist_link" ml
-            WHERE ml."anime_id" = a."id"
+            WHERE ml."anime_id" = a."id"::text
             AND ml."link" ~ '/anime/[0-9]+'
             AND a."mal_id" IS NULL
         `);

--- a/src/migrations/1749945600000-add_mal_id_to_anime.ts
+++ b/src/migrations/1749945600000-add_mal_id_to_anime.ts
@@ -15,7 +15,7 @@ export class addMalIdToAnime1749945600000 implements MigrationInterface {
                 AS integer
             )
             FROM "myanimelist_link" ml
-            WHERE ml."anime_id" = a."id"
+            WHERE ml."anime_id" = a."id"::text
             AND ml."link" ~ '/anime/[0-9]+'
             AND a."mal_id" IS NULL
         `);


### PR DESCRIPTION
## Why

`migration:run` of `1749945600000-add_mal_id_to_anime` fails on the backfill:

```
QueryFailedError: operator does not exist: character varying = uuid
```

The `anime.id` column is `uuid` but `myanimelist_link.anime_id` is `varchar`, so `WHERE ml.anime_id = a.id` has no valid operator. (The migration is transactional, so it rolled back cleanly — the `mal_id` column was **not** left half-applied.)

## Fix

Cast the uuid to text: `ml.anime_id = a.id::text` (text=text). Applied to **both** copies of the migration (`src/migrations/` used by `ENV=local` after build, and root `migrations/` used by the non-local path).

`::text` (not `::uuid`) is deliberate — uuid→text always succeeds, whereas casting the varchar column to uuid would throw on any malformed value.

After this, `migration:run` adds the `mal_id` column and backfills it from the MAL URLs in `myanimelist_link`, which then flows via CDC → anime-sync → the weeb DBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)