### PR TITLE
feat: add --data flag to scrape only selected pieces

### DIFF
--- a/src/modules/commander/scrape.command.ts
+++ b/src/modules/commander/scrape.command.ts
@@ -14,7 +14,13 @@ interface BasicCommandOptions {
   excludeFile?: string
   new?: boolean
   days?: number
+  data?: string[]
 }
+
+// The pieces of data a scrape can produce. `main` (anime metadata + MAL link +
+// seasons) is always scraped as the anchor; `characters` and `episodes` are the
+// expensive extra crawls that this flag lets you skip.
+export const SCRAPE_DATA_TYPES = ['main', 'characters', 'episodes'] as const
 
 
 @Command({
@@ -68,6 +74,7 @@ export class ScraperCommand extends CommandRunner {
         options?.days !== undefined && options?.days !== null
           ? options.days
           : null,
+        options?.data && options.data.length > 0 ? options.data : null,
       )
     }
   }
@@ -131,6 +138,33 @@ export class ScraperCommand extends CommandRunner {
     return parseInt(val, 10)
   }
 
+  @Option({
+    flags: '-D, --data [data]',
+    description:
+      `Comma-separated data to scrape: ${SCRAPE_DATA_TYPES.join(', ')}. ` +
+      `'main' (metadata + seasons) is always scraped; this limits the extra ` +
+      `crawls. Defaults to all. e.g. --data main,episodes`,
+  })
+  getData(val: string): string[] {
+    const requested = val
+      .split(',')
+      .map((v) => v.trim().toLowerCase())
+      .filter((v) => v.length > 0)
+    const valid = requested.filter((v) =>
+      (SCRAPE_DATA_TYPES as readonly string[]).includes(v),
+    )
+    const invalid = requested.filter(
+      (v) => !(SCRAPE_DATA_TYPES as readonly string[]).includes(v),
+    )
+    if (invalid.length > 0) {
+      this.logger.warn(
+        `Ignoring unknown --data values: ${invalid.join(', ')}. ` +
+          `Valid: ${SCRAPE_DATA_TYPES.join(', ')}`,
+      )
+    }
+    return valid
+  }
+
   scrapeSite(
     param: string[],
     option: string,
@@ -140,8 +174,12 @@ export class ScraperCommand extends CommandRunner {
     excludedUrls?: string[],
     newlyadded?: boolean,
     days?: number,
+    dataTypes?: string[],
   ): void {
     this.logger.info(`scape site: ${option}`)
+    if (dataTypes && dataTypes.length > 0) {
+      this.logger.info(`Scraping only: ${dataTypes.join(', ')} (+ main)`)
+    }
     switch (option) {
       case 'anidb':
         this.scapperService.scrapeAnidb(param)
@@ -155,7 +193,8 @@ export class ScraperCommand extends CommandRunner {
           urls,
           excludedUrls,
           newlyadded,
-          days
+          days,
+          dataTypes,
         )
         break
 

--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -26,6 +26,18 @@ export class MyanimelistService {
     },
   }
 
+  // Which pieces of data to scrape. `main` (anime metadata + seasons) is always
+  // the anchor; `characters` and `episodes` are the expensive extra crawls that
+  // the `--data` flag can skip. Defaults to everything.
+  private scrapeDataTypes: Set<string> = new Set(['main', 'characters', 'episodes'])
+
+  setScrapeDataTypes(types?: string[]): void {
+    this.scrapeDataTypes =
+      types && types.length > 0
+        ? new Set(types.map((t) => t.toLowerCase()))
+        : new Set(['main', 'characters', 'episodes'])
+  }
+
   constructor(
     @Inject('winston')
     private readonly logger: Logger,
@@ -569,34 +581,44 @@ export class MyanimelistService {
       }
     }
 
-    // Queue character and staff scraping as a separate task
-    try {
-      await this.puppeteerService.getManager().queue({
-        url,
-        id: upsertedAnime.id,
-        type: 'characters_staff',
-      })
-      this.logger.debug(`Queued character/staff scraping for ${upsertedAnime.title_en}`)
-    } catch (e) {
-      this.logger.error(
-        `Error queuing characters and staff scraping for ${upsertedAnime.title_en}`,
-        e,
-      )
+    // Queue character and staff scraping as a separate task (skipped unless
+    // 'characters' is in the requested --data set).
+    if (this.scrapeDataTypes.has('characters')) {
+      try {
+        await this.puppeteerService.getManager().queue({
+          url,
+          id: upsertedAnime.id,
+          type: 'characters_staff',
+        })
+        this.logger.debug(`Queued character/staff scraping for ${upsertedAnime.title_en}`)
+      } catch (e) {
+        this.logger.error(
+          `Error queuing characters and staff scraping for ${upsertedAnime.title_en}`,
+          e,
+        )
+      }
+    } else {
+      this.logger.debug(`Skipping character/staff scraping for ${upsertedAnime.title_en} (not in --data)`)
     }
 
-    try {
-      await this.puppeteerService.clusterManager.queue({
-        url,
-        id: upsertedAnime.id,
-      }, async ({ page, data }) => {
-        await this.scrapeEpisode({ page, data });
-      });
-      this.logger.info(`Queued episode scraping for ${upsertedAnime.title_en}`);
-    } catch (e) {
-      this.logger.error(
-        `Error queuing episodes for ${upsertedAnime.title_en}`,
-        e,
-      )
+    // Queue episode scraping (skipped unless 'episodes' is in the --data set).
+    if (this.scrapeDataTypes.has('episodes')) {
+      try {
+        await this.puppeteerService.clusterManager.queue({
+          url,
+          id: upsertedAnime.id,
+        }, async ({ page, data }) => {
+          await this.scrapeEpisode({ page, data });
+        });
+        this.logger.info(`Queued episode scraping for ${upsertedAnime.title_en}`);
+      } catch (e) {
+        this.logger.error(
+          `Error queuing episodes for ${upsertedAnime.title_en}`,
+          e,
+        )
+      }
+    } else {
+      this.logger.debug(`Skipping episode scraping for ${upsertedAnime.title_en} (not in --data)`)
     }
 
     this.scrapeRecordService.recordSuccessfulScrape(data)

--- a/src/modules/scraper/scraper.service.ts
+++ b/src/modules/scraper/scraper.service.ts
@@ -97,9 +97,13 @@ export class ScraperService {
     urls?: string[],
     excludedUrls?: string[],
     newlyAdded?: boolean,
-    days?: number
+    days?: number,
+    dataTypes?: string[],
   ) {
     await this.puppeteerService.setup(limit, headless)
+
+    // Limit which pieces of data get scraped (main is always the anchor).
+    this.myanimelistService.setScrapeDataTypes(dataTypes)
 
     // Create a dispatcher function that routes to the correct handler
     const taskDispatcher = async ({ page, data }: any) => {


### PR DESCRIPTION
## What
Adds a `--data` flag to the `scrape` command to limit which pieces of data are scraped, instead of always crawling everything.

```bash
scrape -s myanimelist --data main            # metadata only (skips characters + episodes)
scrape -s myanimelist --data main,episodes   # metadata + episodes
scrape -s myanimelist -D characters,episodes # both extras
# (omitted) = all, as before
```

## Why
A full scrape of each anime also loads a **separate character/staff page** and **every episode page** — often far more crawling than wanted. This flag skips those.

## How
- Values: `main`, `characters`, `episodes` (comma-separated, case-insensitive; unknown values warned + ignored). Default = all.
- **`main`** (anime metadata + MAL link + seasons) is always scraped as the anchor — it's the single anime page already loaded and yields the record id. The flag gates the two expensive extra crawls (`characters`, `episodes`), which are only queued when requested.
- Threaded `ScraperCommand` → `ScraperService.scrapeMyAnimeList` → `MyanimelistService.setScrapeDataTypes`; `scrapeAnimePage` skips queuing the character/staff and episode tasks when not selected.

## Verified
`yarn build` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)