### PR TITLE
feat: support --data selection on the seasonal command

### DIFF
--- a/src/modules/commander/seasonal.command.ts
+++ b/src/modules/commander/seasonal.command.ts
@@ -3,11 +3,13 @@ import { Command, CommandRunner, Option } from 'nest-commander'
 import { Logger } from 'winston'
 import { ScraperService } from '../scraper/scraper.service'
 import { SeasonYear, isValidSeasonYear } from '../common/season.types'
+import { SCRAPE_DATA_TYPES } from './scrape.command'
 
 interface SeasonalCommandOptions {
   season: SeasonYear
   headless?: boolean
   limit?: number
+  data?: string[]
 }
 
 @Command({
@@ -40,10 +42,14 @@ export class SeasonalCommand extends CommandRunner {
     this.logger.info(`Starting seasonal scraping for ${options.season}`)
     
     try {
+      if (options.data && options.data.length > 0) {
+        this.logger.info(`Scraping only: ${options.data.join(', ')} (+ main)`)
+      }
       await this.scraperService.scrapeSeasonalAnime(
         options.season,
         !!options.headless,
-        options.limit
+        options.limit,
+        options.data && options.data.length > 0 ? options.data : null,
       )
       this.logger.info(`Completed seasonal scraping for ${options.season}`)
     } catch (error) {
@@ -73,5 +79,32 @@ export class SeasonalCommand extends CommandRunner {
   })
   getLimit(val: string): number {
     return parseInt(val, 10)
+  }
+
+  @Option({
+    flags: '-D, --data [data]',
+    description:
+      `Comma-separated data to scrape: ${SCRAPE_DATA_TYPES.join(', ')}. ` +
+      `'main' (metadata + seasons) is always scraped; this limits the extra ` +
+      `crawls. Defaults to all. e.g. --data main,episodes`,
+  })
+  getData(val: string): string[] {
+    const requested = val
+      .split(',')
+      .map((v) => v.trim().toLowerCase())
+      .filter((v) => v.length > 0)
+    const valid = requested.filter((v) =>
+      (SCRAPE_DATA_TYPES as readonly string[]).includes(v),
+    )
+    const invalid = requested.filter(
+      (v) => !(SCRAPE_DATA_TYPES as readonly string[]).includes(v),
+    )
+    if (invalid.length > 0) {
+      this.logger.warn(
+        `Ignoring unknown --data values: ${invalid.join(', ')}. ` +
+          `Valid: ${SCRAPE_DATA_TYPES.join(', ')}`,
+      )
+    }
+    return valid
   }
 }

--- a/src/modules/scraper/scraper.service.ts
+++ b/src/modules/scraper/scraper.service.ts
@@ -269,10 +269,14 @@ export class ScraperService {
     seasonYear: SeasonYear,
     headless: boolean,
     limit?: number,
+    dataTypes?: string[],
   ) {
     this.logger.info(`Starting seasonal anime scraping for ${seasonYear}`)
-    
+
     await this.puppeteerService.setup(limit || 50, headless)
+
+    // Limit which pieces of data get scraped (main is always the anchor).
+    this.myanimelistService.setScrapeDataTypes(dataTypes)
 
     // Create a dispatcher function that routes to the correct handler
     const taskDispatcher = async ({ page, data }: any) => {


### PR DESCRIPTION
## What
Follow-up to #7 — extends the `--data` piece-selection flag to the **`seasonal`** command (it scrapes via its own `scrapeSeasonalAnime` flow, so #7's flag didn't apply there).

```bash
seasonal --season SUMMER_2026 --limit 3 --headless --data main   # metadata only
seasonal --season SUMMER_2026 -D main,episodes
# (omitted) = all, unchanged
```

## How
- Add the `-D, --data` option to `SeasonalCommand` (same values/parsing as `scrape`: `main`, `characters`, `episodes`).
- Thread it through `ScraperService.scrapeSeasonalAnime` → `MyanimelistService.setScrapeDataTypes`, which the existing `scrapeAnimePage` gating already respects.

`main` stays the always-scraped anchor; the flag skips the expensive character/episode crawls. Omitting `--data` = all (unchanged).

## Verified
`yarn build` clean; `seasonal --help` lists `-D, --data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)