### PR TITLE
feat: scrape MAL promotional video (trailer_url)

### DIFF
--- a/migrations/1749945700000-add_trailer_url_to_anime.ts
+++ b/migrations/1749945700000-add_trailer_url_to_anime.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addTrailerUrlToAnime1749945700000 implements MigrationInterface {
+    name = 'addTrailerUrlToAnime1749945700000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" ADD "trailer_url" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "trailer_url"`);
+    }
+
+}

--- a/src/migrations/1749945700000-add_trailer_url_to_anime.ts
+++ b/src/migrations/1749945700000-add_trailer_url_to_anime.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addTrailerUrlToAnime1749945700000 implements MigrationInterface {
+    name = 'addTrailerUrlToAnime1749945700000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" ADD "trailer_url" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "trailer_url"`);
+    }
+
+}

--- a/src/modules/anime/repository/anime.entity.ts
+++ b/src/modules/anime/repository/anime.entity.ts
@@ -56,6 +56,9 @@ export class Anime {
   @Column({ name: 'image_url', nullable: true })
   image_url: string
 
+  @Column({ name: 'trailer_url', nullable: true })
+  trailer_url: string
+
   @Column({ name: 'synopsis', nullable: true })
   synopsis: string
 

--- a/src/modules/anime/repository/interface.ts
+++ b/src/modules/anime/repository/interface.ts
@@ -10,6 +10,7 @@ export interface IAnime {
   title_kanji: string
   title_synonyms: string[]
   image_url: string
+  trailer_url?: string
   synopsis: string
   episodes: number
   status: string

--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -461,8 +461,26 @@ export class MyanimelistService {
     ).map(
       genre => getFirstHalfIfEqual(genre),
     )
+    // Promotional video (trailer). MAL embeds it as a youtube-nocookie link,
+    // e.g. <a class="... video-unit promotion" href=".../embed/<id>?...">.
+    // Many anime have no PV, so the selector is allowed to miss.
+    let trailerUrl: string | null = null
+    try {
+      const promoHref = await page.$eval(
+        'a.video-unit.promotion',
+        (el: any) => el.getAttribute('href'),
+      )
+      const match = promoHref && promoHref.match(/\/embed\/([A-Za-z0-9_-]{6,})/)
+      if (match) {
+        trailerUrl = `https://www.youtube.com/watch?v=${match[1]}`
+      }
+    } catch (e) {
+      // No promotional video on this page — leave trailerUrl null.
+    }
+
     const parsedData = {
       image_url: await ClusterManager.pageFindOne(page, '.leftside img', 'src'),
+      trailer_url: trailerUrl,
       ranking: rank,
       anidbid: anidbId,
       title_en: res['english'],


### PR DESCRIPTION
## What
First step of the anime-page **Trailer** feature (MAL-primary + theTVDB-fallback). Captures the MAL promotional video and stores it as `anime.trailer_url`.

## How
- `scrapeAnimePage` reads the promo link (`a.video-unit.promotion`, a `youtube-nocookie.com/embed/<id>` href), parses the video id, and stores a canonical `https://www.youtube.com/watch?v=<id>`. Null when the page has no PV (many don't) — selector is allowed to miss.
- `trailer_url` added to the `Anime` entity + `IAnime`; persists via the existing upsert passthrough (no explicit mapping needed).
- Migration adds the `trailer_url` column (in both `migrations/` and `src/migrations/`, matching the mal_id convention).

## Downstream (separate PRs to follow)
CDC/anime-sync column propagation → anime-api `trailer` field + resolver → frontend trailer section → theTVDB-enrichment fallback (backfill when MAL has none).

## Verified
`yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)