### PR TITLE
feat: generate a public url slug for every anime

### DIFF
--- a/migrations/1787011200000-AddUrlSlugToAnime.ts
+++ b/migrations/1787011200000-AddUrlSlugToAnime.ts
@@ -1,0 +1,153 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Adds anime.url_slug, the public URL segment behind /anime/<slug>.
+ *
+ * Generated here because postgres is the source of truth; anime-api and
+ * anime-sync already have somewhere for the value to land, so the backfill's
+ * CDC events populate MySQL without a second pass.
+ *
+ * Deliberately NOT backfilled in this migration. Updating ~29,600 rows in one
+ * transaction emits ~29,600 CDC events at commit, and anime-sync republishes
+ * each one to the algolia and image topics. The backfill lives in
+ * scripts/backfill-url-slug.sql so it can be run in paced batches.
+ */
+export class AddUrlSlugToAnime1787011200000 implements MigrationInterface {
+    name = 'AddUrlSlugToAnime1787011200000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anime" ADD "url_slug" character varying(255)`);
+
+        // Unique because it is a URL. Nullable rows do not collide under a
+        // unique index in postgres, so rows the backfill has not reached yet
+        // sit happily alongside each other.
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_anime_url_slug" ON "anime" ("url_slug")`);
+
+        // Lowercase, punctuation to hyphens, trimmed. Immutable so it can be
+        // used from an index or a generated expression later if wanted.
+        await queryRunner.query(`
+            CREATE OR REPLACE FUNCTION anime_slug_base(title text) RETURNS text AS $$
+                SELECT btrim(lower(regexp_replace(coalesce(title, ''), '[^a-zA-Z0-9]+', '-', 'g')), '-')
+            $$ LANGUAGE sql IMMUTABLE
+        `);
+
+        // Assigns a slug on insert, and only when one is not already set.
+        //
+        // A slug is never recomputed once assigned. That is the point: a title
+        // correction upstream must not silently change a live URL, which would
+        // break every existing link and search result pointing at it. The
+        // frontend redirects the old id-based URLs; nothing redirects a slug
+        // that quietly rewrote itself.
+        //
+        // The collision checks exclude the row itself. Without that, an upsert
+        // that passes a null slug for an existing row would see its own current
+        // slug sitting in the table and "resolve" the collision by suffixing --
+        // churning a live URL on a no-op save.
+        //
+        // Disambiguation walks title -> -year -> -year-type -> -type before
+        // falling back to an id fragment. Replayed against the full catalogue
+        // of 29,634 anime, every row came out unique and the shapes were:
+        //
+        //   29,362  bare title
+        //      136  -year
+        //      129  title truncated at 80 characters, no suffix needed
+        //        3  -type          (rows with no start_date)
+        //        1  -year-type
+        //        3  id slug        (titles with no latin characters at all)
+        //
+        // Nothing reached the id-fragment backstop. It exists for future data,
+        // not as something a reader should normally see.
+        await queryRunner.query(`
+            CREATE OR REPLACE FUNCTION anime_assign_url_slug() RETURNS trigger AS $$
+            DECLARE
+                base text;
+                candidate text;
+                yr text;
+                ty text;
+            BEGIN
+                IF NEW.url_slug IS NOT NULL AND NEW.url_slug <> '' THEN
+                    RETURN NEW;
+                END IF;
+
+                base := anime_slug_base(coalesce(nullif(NEW.title_en, ''), NEW.title_jp));
+
+                -- A title with no latin characters at all slugifies to nothing;
+                -- fall straight through to the id so the row still gets a URL.
+                IF base IS NULL OR base = '' THEN
+                    NEW.url_slug := 'anime-' || left(replace(NEW.id::text, '-', ''), 12);
+                    RETURN NEW;
+                END IF;
+
+                -- Cap the base so a long title cannot overflow the column and
+                -- hard-fail the insert. Light-novel titles are genuinely this
+                -- long: the worst in the current catalogue slugifies to 160
+                -- characters, and nothing bounds the source titles. Cut back to
+                -- a whole word so the URL does not end mid-syllable; the
+                -- disambiguation cascade below absorbs any collision the
+                -- truncation introduces.
+                IF length(base) > 80 THEN
+                    base := btrim(regexp_replace(left(base, 80), '-[^-]*$', ''), '-');
+                    IF base = '' THEN
+                        base := left(anime_slug_base(coalesce(nullif(NEW.title_en, ''), NEW.title_jp)), 80);
+                    END IF;
+                END IF;
+
+                candidate := base;
+                IF NOT EXISTS (SELECT 1 FROM anime WHERE url_slug = candidate AND id <> NEW.id) THEN
+                    NEW.url_slug := candidate;
+                    RETURN NEW;
+                END IF;
+
+                yr := to_char(NEW.start_date, 'YYYY');
+                IF yr IS NOT NULL THEN
+                    candidate := base || '-' || yr;
+                    IF NOT EXISTS (SELECT 1 FROM anime WHERE url_slug = candidate AND id <> NEW.id) THEN
+                        NEW.url_slug := candidate;
+                        RETURN NEW;
+                    END IF;
+                END IF;
+
+                ty := anime_slug_base(NEW.type);
+                IF yr IS NOT NULL AND ty <> '' THEN
+                    candidate := base || '-' || yr || '-' || ty;
+                    IF NOT EXISTS (SELECT 1 FROM anime WHERE url_slug = candidate AND id <> NEW.id) THEN
+                        NEW.url_slug := candidate;
+                        RETURN NEW;
+                    END IF;
+                END IF;
+
+                -- Type without the year, for the rows that have no start_date.
+                -- Without this a dateless collision skips both branches above
+                -- and lands on the id fragment, when "legend-of-exorcism-ona"
+                -- was available and reads far better.
+                IF ty <> '' THEN
+                    candidate := base || '-' || ty;
+                    IF NOT EXISTS (SELECT 1 FROM anime WHERE url_slug = candidate AND id <> NEW.id) THEN
+                        NEW.url_slug := candidate;
+                        RETURN NEW;
+                    END IF;
+                END IF;
+
+                -- Backstop. Unique by construction, so an insert never fails on
+                -- the slug index no matter how contrived the title.
+                NEW.url_slug := base || '-' || left(replace(NEW.id::text, '-', ''), 8);
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+        `);
+
+        await queryRunner.query(`
+            CREATE TRIGGER anime_url_slug_trigger
+            BEFORE INSERT OR UPDATE ON "anime"
+            FOR EACH ROW EXECUTE FUNCTION anime_assign_url_slug()
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TRIGGER IF EXISTS anime_url_slug_trigger ON "anime"`);
+        await queryRunner.query(`DROP FUNCTION IF EXISTS anime_assign_url_slug()`);
+        await queryRunner.query(`DROP FUNCTION IF EXISTS anime_slug_base(text)`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_anime_url_slug"`);
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "url_slug"`);
+    }
+}

--- a/scripts/backfill-url-slug.sh
+++ b/scripts/backfill-url-slug.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Backfill anime.url_slug in paced batches.
+#
+# Each batch is its own transaction, so CDC emits its events as the batch
+# commits rather than all at once. That matters: anime-sync republishes every
+# anime update to the algolia and image topics, so an unpaced backfill of
+# ~29,600 rows would fire that many re-index operations and image messages in
+# one burst.
+#
+# Usage:
+#   PGHOST=... PGUSER=... PGPASSWORD=... PGDATABASE=anime ./backfill-url-slug.sh [pause_seconds]
+set -euo pipefail
+
+PAUSE="${1:-2}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+while :; do
+    remaining=$(psql -v ON_ERROR_STOP=1 -t -A -f "${SCRIPT_DIR}/backfill-url-slug.sql" | tail -1)
+    echo "$(date -u +%H:%M:%S)  remaining: ${remaining}"
+    [ "${remaining}" = "0" ] && break
+    sleep "${PAUSE}"
+done
+
+echo "backfill complete"

--- a/scripts/backfill-url-slug.sql
+++ b/scripts/backfill-url-slug.sql
@@ -1,0 +1,25 @@
+-- One batch of the url_slug backfill.
+--
+-- Setting url_slug to NULL is what does the work: the BEFORE UPDATE trigger
+-- sees a null slug and assigns one. Nothing else about the row changes.
+--
+-- Deliberately a single batch rather than a loop. Wrapping the whole backfill
+-- in one transaction -- or one DO block, which is the same thing -- would emit
+-- every CDC event at commit no matter how it was batched internally. Pacing
+-- has to happen between transactions, which is what backfill-url-slug.sh does.
+--
+-- FOR UPDATE SKIP LOCKED so a run does not fight the scraper for rows.
+
+\set batch_size 500
+
+WITH batch AS (
+    SELECT id FROM anime
+    WHERE url_slug IS NULL
+    ORDER BY id
+    LIMIT :batch_size
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE anime a SET url_slug = NULL
+FROM batch b WHERE a.id = b.id;
+
+SELECT count(*) AS remaining FROM anime WHERE url_slug IS NULL;

--- a/src/modules/anime/repository/anime.entity.ts
+++ b/src/modules/anime/repository/anime.entity.ts
@@ -23,6 +23,12 @@ export class Anime {
   @Column({ name: 'mal_id', nullable: true, type: 'int' })
   mal_id: number
 
+  // Assigned by a postgres trigger on insert and never rewritten afterwards,
+  // because it is a public URL. Leave it undefined when saving; setting it to
+  // null asks the trigger to mint a fresh one.
+  @Column({ name: 'url_slug', nullable: true })
+  url_slug: string
+
   @Column({ name: 'type', enum: RECORD_TYPE, default: RECORD_TYPE.Anime })
   type: RECORD_TYPE
 


### PR DESCRIPTION
Adds `anime.url_slug`, the segment behind `/anime/<slug>`. Generated in postgres because postgres is the source of truth — the backfill's CDC events populate MySQL on their own, so there is no second migration to run there.

This is the third of four steps. anime-api (#52) and anime-sync (#17) already have somewhere for the value to land, so nothing here depends on a deploy landing first.

## Slugs never move

A slug is assigned on insert and never rewritten, including when the title is corrected upstream. Rewriting one would break every link and search result pointing at it, and unlike `/show/<id>` — which the frontend will redirect — nothing redirects a URL that quietly changed on its own.

The collision checks exclude the row itself (`AND id <> NEW.id`). Without that, an upsert passing a null slug would see the row's *own* current slug in the table and "resolve" the collision by suffixing it, churning a live URL on a no-op save.

## Verified by replay, not by inspection

I loaded all 29,634 production titles into a throwaway postgres, applied this migration verbatim (SQL extracted from the file, not retyped), and ran the backfill:

| shape | rows |
|---|---:|
| bare title | 29,362 |
| `-year` | 136 |
| truncated at 80 chars, no suffix | 129 |
| `-type` (rows with no `start_date`) | 3 |
| `-year-type` | 1 |
| id slug (titles with no latin characters) | 3 |

All 29,634 unique, longest slug 85 characters, and **nothing reached the id-fragment backstop**.

Two things that replay caught which reading the code would not have:

- **Dateless rows fell straight to an id fragment.** The `-year` and `-year-type` branches are both guarded on a non-null `start_date`, so a collision with no date skipped both. `legend-of-exorcism-ona` was available and reads far better. Added a `-type` branch; that removed the last 3 id-fragment slugs.
- **Slugs were unbounded.** The longest title slugified to 160 characters against a `varchar(255)` column, and nothing bounds the source titles — a long enough one would overflow and fail the insert outright. The base is now capped at 80 characters, cut back to a whole word.

Rollback and re-apply were both exercised.

## The backfill is not in the migration

Updating ~29,600 rows in one transaction emits ~29,600 CDC events at commit, and anime-sync republishes each one to the algolia and image topics. Batching inside a transaction changes nothing — the events still land together — so pacing has to happen *between* transactions. `scripts/backfill-url-slug.sh` runs one batch per transaction with a configurable pause.

**image-sync#11 should be deployed before the backfill runs.** Without it each of those events refetches an image we already hold; with it they are skipped on a size comparison.

## Not covered here

The `/anime/<slug>` route and the `/show/<id>` redirect are the next PR, so nothing user-facing changes when this merges — the column is populated and idle until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)