### PR TITLE
fix: capture voice actor birthday, birthplace and biography

### DIFF
--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -966,19 +966,30 @@ export class MyanimelistService {
     ).then(text => text?.replace('Family name:', '').trim())
       .catch(() => null);
 
-    const birthday = await ClusterManager.pageFindOne(
-      page,
-      'div.spaceit_pad:has(span.dark_text:contains("Birthday"))',
-      'textContent'
-    ).then(text => text?.replace('Birthday:', '').trim())
-      .catch(() => null);
+    // :contains() is a jQuery selector, not CSS -- querySelector throws
+    // SyntaxError on it, the .catch below swallowed that, and every one of the
+    // 22,071 staff rows ended up with a null birthday. MAL puts it in a plain
+    // div.spaceit_pad as "Birthday: Feb 25, 1989", so read them and pick.
+    const birthday = await page.$$eval('div.spaceit_pad', (els: Element[]) => {
+      for (const el of els) {
+        const text = (el.textContent || '').trim();
+        if (text.startsWith('Birthday:')) {
+          // MAL renders these with irregular internal spacing ("Feb  25, 1989").
+          return text.replace('Birthday:', '').replace(/\s+/g, ' ').trim();
+        }
+      }
+      return null;
+    }).catch(() => null);
 
+    // MAL uses at least three labels for this across people pages -- "Hometown",
+    // "Birthplace" and "Birth place". Matching only the last is why it was
+    // populated for 786 of 22,071 staff.
     const birthPlace = await ClusterManager.pageFindOne(
       page,
       'div.people-informantion-more',
       'innerHTML'
     ).then(html => {
-      const match = html.match(/Birth place:\s*(.+?)<br>/);
+      const match = html.match(/(?:Birth\s?place|Hometown):\s*(.+?)<br>/i);
       return match ? match[1].trim() : null;
     }).catch(() => null);
 
@@ -1000,18 +1011,34 @@ export class MyanimelistService {
       return match ? match[1].trim() : null;
     }).catch(() => null);
 
+    // The biography sits in the same block as the key/value facts, after them.
+    // This used to drop three hardcoded labels and keep the rest, which failed
+    // twice over: 'innerText' was unsupported by pageFindOne so the input was
+    // always null, and the real labels vary (Hometown, Height, Member
+    // Favorites, ...) so hardcoding three of them would have leaked the others
+    // into the biography anyway.
+    //
+    // Drop every leading "Label: value" line instead, and keep from the first
+    // line of prose onwards.
     const summary = await ClusterManager.pageFindOne(
       page,
       'div.people-informantion-more',
       'innerText'
-    ).then(text => {
-      return text
-        .split('\n')
-        .filter(line =>
-          !line.includes('Birth place:') &&
-          !line.includes('Blood type:') &&
-          !line.includes('Hobbies:')
-        ).join('\n').trim();
+    ).then((text: string | null) => {
+      if (!text) return null;
+      const lines = text.split('\n');
+      let i = 0;
+      while (i < lines.length) {
+        const line = lines[i].trim();
+        // A fact line, or the blank line separating the facts from the prose.
+        if (line === '' || /^[A-Z][A-Za-z ]{0,24}:\s/.test(line)) {
+          i++;
+          continue;
+        }
+        break;
+      }
+      const body = lines.slice(i).join('\n').trim();
+      return body || null;
     }).catch(() => null);
 
     const image = await ClusterManager.pageFindOne(

--- a/src/modules/puppeteer/clusterManager.ts
+++ b/src/modules/puppeteer/clusterManager.ts
@@ -96,6 +96,14 @@ class ClusterManager {
           if (subTarget === 'textContent') {
             return element.textContent
           }
+          // innerText is a property, not an attribute. Without this branch it
+          // fell through to getAttribute('innerText'), which returns null for
+          // every element -- and callers that immediately .split() it threw,
+          // silently, into a .catch(() => null). That is why every voice actor
+          // summary was empty.
+          if (subTarget === 'innerText') {
+            return (element as HTMLElement).innerText
+          }
           try {
             return element.getAttribute(subTarget)
           } catch (error) {


### PR DESCRIPTION
You were right that information is missing. Three independent silent failures meant most of what we store about a voice actor was never written at all.

Measured across **22,071 staff rows**:

```
image        22,023   99.8%
language      6,868   31%
blood_type    1,020    4.6%
birth_place     786    3.6%
hobbies         332    1.5%
birthday          0    0%     ← never written, ever
summary           0    0%     ← never written, ever
```

`blood_type` and `hobbies` come from the *same* scrape as `birthday`, so the scrape runs — these two fields just never land.

## 1. `birthday` — an invalid selector

```js
'div.spaceit_pad:has(span.dark_text:contains("Birthday"))'
```

`:contains()` is a **jQuery selector, not CSS**. `querySelector` throws `SyntaxError` on it every time, and `.catch(() => null)` buried that. Confirmed in a browser:

```
SyntaxError: '...:contains("Birthday")' is not a valid selector
```

MAL puts the value in a plain `div.spaceit_pad` as `"Birthday: Feb 25, 1989"`, so we read those and pick the match. Also collapses MAL's irregular internal spacing (`"Feb  25, 1989"`).

## 2. `summary` — an unsupported property

`pageFindOne` handles `innerHTML`, `outerHTML` and `textContent`, then falls through to `element.getAttribute(subTarget)`. Summary asked for **`innerText`** — a *property*, not an attribute — so `getAttribute` returned `null` for every element, and the `.split('\n')` that followed threw into the same silent catch.

Added an `innerText` branch to `pageFindOne`, which fixes it for any other caller too.

Its filter was independently wrong: it dropped three hardcoded labels and kept the rest, but the real labels vary by page (`Hometown`, `Height`, `Favorites`, `Member Favorites`), so those would have leaked into the biography. It now drops every leading `"Label: value"` line and keeps the prose.

## 3. `birth_place` — one of three labels

The regex matched only `Birth place:`. MAL uses at least **three** variants across pages — I found two different ones in the first two pages I checked:

```
Kana Hanazawa   "Hometown: Tokyo, Japan"
Akira Ishida    "Birthplace: Nisshin, Aichi Prefecture, Japan"
```

That's the 3.6%. Now matches `Hometown`, `Birthplace` and `Birth place`, case-insensitively.

## Verified

Against two live MAL people pages using different label variants — all four fields extract from both:

```
birthday:    "Nov 2, 1967"
birthPlace:  "Nisshin, Aichi Prefecture, Japan"
bloodType:   "O"
summary:     "Voted the most popular voice actor in the Animage Anime Grand Prix in 2004..."
```

`tsc --noEmit` clean.

## Not addressed

- **`Height`** is on these pages with no column to store it — would need a migration.
- **The detail scrape only reaches ~5% of staff.** Even with correct selectors, coverage stays limited until that's looked at separately; `blood_type` at 1,020 rows is effectively a count of how often `scrapeVoiceActorDetails` has ever completed.
- This only affects **future** scrapes. Prod runs the scraper weekly; existing rows fill in as people are re-scraped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)