### PR TITLE
fix: make myanimelist_link resolvable by link, and generalise its target

### DIFF
--- a/docs/manga-and-works.md
+++ b/docs/manga-and-works.md
@@ -1,0 +1,220 @@
+# Manga, light novels, and source works
+
+Plan for scraping the works anime are adapted from, and using them to relate
+anime to each other. Written 2026-08-22, paused before implementation.
+
+## Why
+
+Anime adaptations of the same source are invisible to us today.
+
+```
+Fruits Basket        2001  and  2019
+Hunter x Hunter      1999  and  2011
+Fullmetal Alchemist  2003  and  Brotherhood
+```
+
+Those share no TheTVDB series id and frequently no voice cast, so neither
+signal behind `Anime.relatedAnime` finds them. The manga is the only thing
+connecting them.
+
+`anime.source` cannot help: it records a *category*, not an identity.
+
+```
+Original      13,334      Manga   6,110      Light novel  1,362
+Unknown        2,956      Game    1,665      Web manga      831
+Novel            808      Web novel 470      4-koma         368
+```
+
+We know an anime came from a manga. We never know *which* manga.
+
+## Decisions already made
+
+These were reasoned through with evidence. Recorded so they don't get
+relitigated, not because they can't change.
+
+### One `work` table, not `manga` + `light_novel` + ...
+
+MAL serves manga and light novels from **one namespace** — both live at
+`myanimelist.net/manga/<id>` — with a `Type` field distinguishing Manga, Light
+Novel, Novel, One-shot, Doujinshi, Manhwa, Manhua. Compared field-by-field:
+
+```
+Manga (Vinland Saga)        Light Novel (Spice & Wolf)
+  Volumes, Chapters           Volumes, Chapters
+  Status, Published           Status, Published
+  Genres, Theme               Genres, Themes
+  Demographic                 -
+  Serialization, Authors      Serialization, Authors
+  Score, Ranked, Popularity   Score, Ranked, Popularity
+```
+
+Effectively identical. The only divergence is `Demographic`. One table with a
+`type` column, one scraper path, one page parser.
+
+### `work` is a sibling of `anime`, not a merge into `items`
+
+Anime and works differ in **shape**, not just label:
+
+```
+anime only:  episodes, episode_count, broadcast, duration/ep, season,
+             studios, licensors, thetvdbid, anidbid, streaming, air times
+work only:   chapters, volumes, published_from/to, serialization, authors
+shared:      titles, synopsis, image, score, ranking, mal_id, tags, characters
+```
+
+Merging them means half the columns NULL on every row, `WHERE type='anime'` on
+every query, the already-optimised airing query scanning ~70k manga rows, and
+the `anime_episode_count` triggers needing type guards. The blast radius is
+**54 `anime_id` references across migrations**, plus `user_anime` in
+user-service and list-service.
+
+The rule: **split on shape, discriminate on label.** MAL's manga family is one
+shape wearing several labels. A visual novel from VNDB would be a second shape
+— that is when a per-type detail table earns its keep, and the model stays open
+to it.
+
+### `myanimelist_link` needs a generic target
+
+```sql
+myanimelist_link(type, name, link, anime_id)
+                                   ^^^^^^^^
+```
+
+`RECORD_TYPE` has carried `{ Anime, Manga, Character, Staff, Studio, User }`
+since the table was created and only ever held `anime`, because `anime_id` is
+the only foreign key. A manga link has a type to declare and nowhere to point.
+
+This matters beyond manga: this table is how a scraped MAL URL becomes one of
+our ids, and it is what lets us record a relationship to something not yet
+scraped — store the URL now, resolve when the other side arrives. Without a
+generic target, cross-record links are dropped at write time and never
+recovered.
+
+Not CDC'd (no `myanimelist_link` table exists in MySQL), so changing it has no
+downstream blast radius.
+
+## Open decision: get off Vitess first
+
+**Preference stated: move to Postgres, off PlanetScale/Vitess.** Migrations are
+materially easier there, and today gave concrete examples:
+
+- **No foreign keys.** `000032_create_tags_table` says so in a comment —
+  "Foreign keys not used due to Vitess/PlanetScale compatibility".
+- **`migrate up` cannot build a database from scratch.** An earlier migration
+  uses `DELIMITER`, which golang-migrate cannot parse, so the chain dies
+  partway. New environments cannot be bootstrapped from migrations alone.
+- **Accent folding by hand.** `000038_add_url_slug_to_anime_staff` needed a
+  ~40-branch nested `REPLACE` chain to fold accents in a generated column.
+  Postgres does that with `unaccent()`.
+
+This changes the manga sequencing, because building `work` under the current
+architecture means building it **twice**:
+
+```
+today:      Postgres table -> Debezium topic -> sync consumer command
+            -> MySQL migration -> reconcileTables entry -> anime-api repository
+Postgres:   Postgres table -> anime-api repository
+```
+
+Every table added before the move is pipeline work that gets thrown away. And
+`work` is not one table for long — characters, authors, and relations follow.
+
+### Suggested approach: strangler, not big bang
+
+Do not block manga behind a full MySQL to Postgres migration, and do not build
+manga on MySQL. Instead:
+
+1. `work` lives in Postgres and **anime-api reads it directly**, skipping CDC
+   entirely.
+2. `anime` keeps reading MySQL as today.
+3. The join is application-level and cheap: `anime.source_work_id` lives on the
+   anime row in MySQL, so "this anime's source" is one Postgres lookup by id,
+   and "anime adapting this work" is one MySQL query by `source_work_id`.
+
+This proves the Postgres-direct read path on a new, low-traffic entity family
+before touching the load-bearing anime path. If it works, migrate anime after.
+If it does not, little is lost.
+
+Cost to weigh: anime-api holds two database connections for a period, and one
+service reading two stores is a real complexity. Bounded, and temporary if the
+full move follows.
+
+**Counter-argument worth keeping honest:** prod MySQL is PlanetScale, a managed
+service, and is one of the few components in this stack that has not caused
+trouble. In-cluster Postgres on seven nodes that have had memory pressure and a
+`NodeNotReady` is a different risk profile. The strangler order matters partly
+because it lets that be evaluated on `work` before it is bet on `anime`.
+
+## Scope of the payoff
+
+MAL's manga database covers the manga-family sources only:
+
+```
+reachable:    Manga 6,110 + Light novel 1,362 + Web manga 831 + Novel 808
+              + Web novel 470 + 4-koma 368            ~= 10,300 anime
+not on MAL:   Game 1,665 + Visual novel 1,212         (needs VNDB/IGDB)
+no source:    Original 13,334                          (cannot participate)
+```
+
+So roughly a third of the catalogue gains source-work relations. That is still
+every re-adaptation case, which nothing else reaches.
+
+## Steps
+
+Ordered. Nothing after step 1 is started.
+
+1. **`myanimelist_link.record_id`** — drafted, uncommitted, on branch
+   `feat/work-table`:
+   `migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts`.
+   Adds `record_id`, backfills from `anime_id`, indexes `(link)` uniquely and
+   `(type, record_id)`. Leaves `anime_id` in place so the migration and the
+   code change can deploy independently; drop it in a follow-up.
+
+2. **Entity and repository** — `MyanimelistLinks.recordId`, and resolution
+   helpers that take a `RECORD_TYPE`.
+
+3. **`work` table** in Postgres:
+
+   ```
+   work(id, mal_id, type, title_en, title_jp, title_synonyms, synopsis,
+        image_url, status, volumes, chapters, published_from, published_to,
+        demographic, serialization, authors, score, ranking, members,
+        favorites, created_at, updated_at)
+   ```
+
+   `type` in `{ MANGA, LIGHT_NOVEL, NOVEL, WEB_MANGA, ONE_SHOT, DOUJINSHI,
+   MANHWA, MANHUA }`. Note `authors` as a JSON-ish text column follows the
+   existing `studios`/`genres` convention. That convention is known to be
+   dirty -- 41% of `anime.studios` is the literal placeholder
+   `["None found"," add some"]`, and a comma-split bug made `" Inc."` a studio
+   with 19 anime -- so normalising `authors` the way genres became `tags`
+   is worth doing at creation rather than later.
+
+4. **`anime.source_work_id`** — nullable, indexed. One column covers the
+   overwhelming majority; an anime adapting several works is rare enough to
+   defer a link table.
+
+5. **Scraper: MAL manga pages.** Same Puppeteer cluster, session and captcha
+   handling as the anime path. Parse the sidebar labels listed above.
+
+6. **Scraper: capture the source link on anime pages.** Store the MAL URL
+   unresolved, resolve later via `myanimelist_link` — the same pattern that
+   makes relations recoverable.
+
+7. **Read path** — per the strangler decision above.
+
+8. **`AnimeRelation.SHARED_SOURCE`** in anime-api. The enum already exists and
+   documents this gap; adding a value is non-breaking, and the frontend already
+   groups by relation kind and falls back for unknown kinds.
+
+## Things deliberately not decided
+
+- **Characters shared between an anime and its manga.** `anime_character` is
+  keyed `(anime_id, name)` — per-work rows, not per-character. Manga characters
+  need either a parallel table or a real `character` + `appearance` model. Real
+  question, separate from this one.
+- **Renaming `anime-api`.** Serving works from a service called anime-api makes
+  the name a lie. Renaming touches Argo apps, subgraph registration and DNS.
+  Accepted as historical for now.
+- **Work slugs.** `/manga/<slug>` will want the same treatment `anime.url_slug`
+  got. Not needed until works have pages.

--- a/docs/manga-and-works.md
+++ b/docs/manga-and-works.md
@@ -1,7 +1,9 @@
 # Manga, light novels, and source works
 
 Plan for scraping the works anime are adapted from, and using them to relate
-anime to each other. Written 2026-08-22, paused before implementation.
+anime to each other. Written 2026-08-22, paused before implementation, and
+revised 2026-08-24 after the read store moved to Postgres and the event
+pipeline moved to NATS -- see "Resolved since this was written".
 
 ## Why
 
@@ -93,57 +95,64 @@ recovered.
 Not CDC'd (no `myanimelist_link` table exists in MySQL), so changing it has no
 downstream blast radius.
 
-## Open decision: get off Vitess first
+## Resolved since this was written: the read store is Postgres
 
-**Preference stated: move to Postgres, off PlanetScale/Vitess.** Migrations are
-materially easier there, and today gave concrete examples:
+The move happened. `anime-api` reads
+`weeb-vip-db...rds.amazonaws.com:5432` -- Postgres, not PlanetScale -- and so
+do the sync services. The only MySQL left in the estate is `mysql-staging-0`
+in `weeb-staging`.
 
-- **No foreign keys.** `000032_create_tags_table` says so in a comment —
-  "Foreign keys not used due to Vitess/PlanetScale compatibility".
-- **`migrate up` cannot build a database from scratch.** An earlier migration
-  uses `DELIMITER`, which golang-migrate cannot parse, so the chain dies
-  partway. New environments cannot be bootstrapped from migrations alone.
-- **Accent folding by hand.** `000038_add_url_slug_to_anime_staff` needed a
-  ~40-branch nested `REPLACE` chain to fold accents in a generated column.
-  Postgres does that with `unaccent()`.
+Two of the three migration pains listed here are therefore gone: foreign keys
+are available, and `unaccent()` replaced the ~40-branch `REPLACE` chain
+(`anime-api` migration `000051`). Whatever remains of the `DELIMITER` problem
+belongs to the retired MySQL chain, not to new work.
 
-This changes the manga sequencing, because building `work` under the current
-architecture means building it **twice**:
+`animeschedule-sync` and `image-sync-backfill` still carry
+`us-east.connect.psdb.cloud:3306` and a `pscale_pw_...` credential in their
+values. Those jobs are either broken or the last thing holding PlanetScale
+open; worth settling before building on the assumption that it is gone.
+
+### What did not change: the shape
+
+The pipeline is the same, with both ends now Postgres:
 
 ```
-today:      Postgres table -> Debezium topic -> sync consumer command
-            -> MySQL migration -> reconcileTables entry -> anime-api repository
-Postgres:   Postgres table -> anime-api repository
+scraper Postgres -> Debezium -> NATS (ANIMEDB) -> sync service -> read-store Postgres
 ```
 
-Every table added before the move is pipeline work that gets thrown away. And
-`work` is not one table for long — characters, authors, and relations follow.
+So the earlier concern still stands, and the strangler that was proposed to
+avoid it does not apply -- there is no second store to strangle. A new entity
+is defined twice, once in each database, with a consumer between them.
 
-### Suggested approach: strangler, not big bang
+The CDC leg, at least, is free. Debezium runs with
+`schema.include.list=public` and no table filter, so it captures **every**
+table in the scraper's schema -- `migrations` and `scraper` are in the stream
+today alongside the real ones. A new table produces
+`anime-db.public.work` on its first row with no configuration change, no new
+replication slot, and no new stream: `ANIMEDB` already claims `anime-db.>` and
+its retention covers it.
 
-Do not block manga behind a full MySQL to Postgres migration, and do not build
-manga on MySQL. Instead:
+What is not free is the consumer and the second definition:
 
-1. `work` lives in Postgres and **anime-api reads it directly**, skipping CDC
-   entirely.
-2. `anime` keeps reading MySQL as today.
-3. The join is application-level and cheap: `anime.source_work_id` lives on the
-   anime row in MySQL, so "this anime's source" is one Postgres lookup by id,
-   and "anime adapting this work" is one MySQL query by `source_work_id`.
+```
+free:      the Debezium capture, the subject, the stream, the retention
+to build:  a migration in the scraper's Postgres
+           a consumer command in a sync service
+           a migration in the read store
+           a repository and schema in anime-api
+```
 
-This proves the Postgres-direct read path on a new, low-traffic entity family
-before touching the load-bearing anime path. If it works, migrate anime after.
-If it does not, little is lost.
+Two notes for whoever writes the consumer, learned the hard way on 2026-08-24:
 
-Cost to weigh: anime-api holds two database connections for a period, and one
-service reading two stores is a real complexity. Bounded, and temporary if the
-full move follows.
-
-**Counter-argument worth keeping honest:** prod MySQL is PlanetScale, a managed
-service, and is one of the few components in this stack that has not caused
-trouble. In-cluster Postgres on seven nodes that have had memory pressure and a
-`NodeNotReady` is a different risk profile. The strangler order matters partly
-because it lets that be evaluated on `work` before it is bet on `anime`.
+- It consumes `anime-db.>`, which is Debezium's stream, so it needs
+  `NATSSTREAMNAME=ANIMEDB`. JetStream refuses two streams whose subjects
+  overlap, and without this the driver tries to create its own.
+- If it also *publishes* -- an image event, say -- it must build a **second**
+  driver for that, with no `StreamName`. ep uses one driver's stream for both
+  directions, and publishing through the consumer's driver asks JetStream to
+  add the published subject to the CDC stream, which it refuses. The message
+  then never acks and redelivers forever. This wedged four of six consumers in
+  production.
 
 ## Scope of the payoff
 
@@ -163,8 +172,8 @@ every re-adaptation case, which nothing else reaches.
 
 Ordered. Nothing after step 1 is started.
 
-1. **`myanimelist_link.record_id`** — drafted, uncommitted, on branch
-   `feat/work-table`:
+1. **`myanimelist_link.record_id`** — written, committed on branch
+   `feat/work-table`, not yet raised as a pull request:
    `migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts`.
    Adds `record_id`, backfills from `anime_id`, indexes `(link)` uniquely and
    `(type, record_id)`. Leaves `anime_id` in place so the migration and the
@@ -201,7 +210,9 @@ Ordered. Nothing after step 1 is started.
    unresolved, resolve later via `myanimelist_link` — the same pattern that
    makes relations recoverable.
 
-7. **Read path** — per the strangler decision above.
+7. **Read path** — ordinary. `work` is a table in the read store beside
+   `anime`, so `anime.source_work_id` is a column and both directions are a
+   plain join. No second connection, no cross-store lookup.
 
 8. **`AnimeRelation.SHARED_SOURCE`** in anime-api. The enum already exists and
    documents this gap; adding a value is non-breaking, and the frontend already

--- a/migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts
+++ b/migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Generalises myanimelist_link so it can resolve a MAL URL to something other
+ * than an anime.
+ *
+ * The table's `type` column has carried a RECORD_TYPE enum since it was created
+ * -- anime, manga, character, staff, studio, user -- but only ever held 'anime',
+ * because the only foreign key on the row is anime_id. A manga link has had a
+ * type to declare and nowhere to point.
+ *
+ * That matters for more than manga. This table is how a scraped MAL URL becomes
+ * one of our ids, and it is what lets us record a relationship to something we
+ * have not scraped yet: store the URL now, resolve it when the other side
+ * arrives. Without a generic target, every cross-record link has to be dropped
+ * at write time and is never recovered.
+ *
+ * anime_id is left in place rather than renamed. Nothing downstream reads this
+ * table -- it exists only inside the scraper and is not carried by CDC, so a
+ * rename would be safe from MySQL's point of view -- but the scraper's own
+ * entity and repository still reference animeId, and a rename makes the
+ * migration and the code change a single atomic deploy or an outage. Expanding
+ * first lets the two land independently; the drop is a follow-up once nothing
+ * reads the old column.
+ */
+export class GeneralizeMyanimelistLinkRecordId1787184000000 implements MigrationInterface {
+    name = 'GeneralizeMyanimelistLinkRecordId1787184000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "myanimelist_link" ADD "record_id" character varying(36)`);
+
+        // Backfill: every existing row is an anime link by construction.
+        await queryRunner.query(`UPDATE "myanimelist_link" SET "record_id" = "anime_id" WHERE "anime_id" IS NOT NULL`);
+
+        // The resolution lookup is "given this MAL URL, what is our id", and it
+        // runs once per related entry on every scraped page. Unique on the URL
+        // because one MAL URL is one record; the type is carried in the index so
+        // the common query can be answered without touching the heap.
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_myanimelist_link_link" ON "myanimelist_link" ("link")`);
+        await queryRunner.query(`CREATE INDEX "IDX_myanimelist_link_type_record" ON "myanimelist_link" ("type", "record_id")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_myanimelist_link_type_record"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_myanimelist_link_link"`);
+        await queryRunner.query(`ALTER TABLE "myanimelist_link" DROP COLUMN "record_id"`);
+    }
+}

--- a/migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts
+++ b/migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts
@@ -29,6 +29,35 @@ export class GeneralizeMyanimelistLinkRecordId1787184000000 implements Migration
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "myanimelist_link" ADD "record_id" character varying(36)`);
 
+        // Collapse duplicate links before the unique index below, which would
+        // otherwise fail outright: production holds 30,641 rows over 30,155
+        // distinct links -- 485 links duplicated across 971 rows, one of them
+        // three times.
+        //
+        // They are safe to collapse. No link maps to two different anime: the
+        // duplicates are one record scraped under different titles, because
+        // upsert() matched on name before link, so "Kikou Ryouhei Merowlink",
+        // "Kikou Ryouhei Mellowlink" and "Armor Hunter Mellowlink" became three
+        // rows for one URL. 399 of the duplicate rows never resolved to an anime
+        // at all.
+        //
+        // Keep the row that resolves to an anime, then the most recently
+        // updated, then the highest id -- deterministic, and it never discards a
+        // resolution in favour of a NULL.
+        await queryRunner.query(`
+            DELETE FROM "myanimelist_link"
+            WHERE "id" IN (
+                SELECT "id" FROM (
+                    SELECT "id", row_number() OVER (
+                        PARTITION BY "link"
+                        ORDER BY ("anime_id" IS NOT NULL) DESC, "updated_at" DESC, "id" DESC
+                    ) AS rn
+                    FROM "myanimelist_link"
+                ) ranked
+                WHERE ranked.rn > 1
+            )
+        `);
+
         // Backfill: every existing row is an anime link by construction.
         await queryRunner.query(`UPDATE "myanimelist_link" SET "record_id" = "anime_id" WHERE "anime_id" IS NOT NULL`);
 

--- a/src/modules/myanimelist/repository/myanimelist.repository.ts
+++ b/src/modules/myanimelist/repository/myanimelist.repository.ts
@@ -50,14 +50,25 @@ export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
       body,
       nullFields,
     ) as MyanimelistLinks
+    // Match on the link first.
+    //
+    // This matched on name+type first and fell back to the link, which made a
+    // retitled entry a new row rather than an update: MAL lists the same URL as
+    // "Kikou Ryouhei Merowlink", "Kikou Ryouhei Mellowlink" and "Armor Hunter
+    // Mellowlink", and production ended up with all three. 485 links were
+    // duplicated that way across 971 rows, and 399 of those rows never resolved
+    // to an anime.
+    //
+    // The link is the identity here -- one MAL URL is one record, which is what
+    // the unique index added alongside this asserts. The name is a label on it
+    // and changes freely.
     // eslint-disable-next-line
     let savedLink: MyanimelistLinks = await this.findOne({
-      name: cleanBody.name,
-      type: cleanBody.type,
+      where: { link: cleanBody.link },
     })
     if (!savedLink) {
       savedLink = await this.findOne({
-        where: { link: cleanBody.link },
+        where: { name: cleanBody.name, type: cleanBody.type },
       })
     }
 


### PR DESCRIPTION
Step 1 of [the manga/works plan](docs/manga-and-works.md). Two changes that have to land together.

## What it does

`myanimelist_link` gains `record_id`, so a scraped MAL URL can resolve to something other than an anime. The table's `type` column has carried a `RECORD_TYPE` enum since creation — anime, manga, character, staff, studio, user — but only ever held `anime`, because `anime_id` is the only foreign key on the row. A manga link has had a type to declare and nowhere to point.

`anime_id` stays, so this migration and the code that reads it deploy independently. Dropping it is a follow-up.

## ⚠️ The unique index would have failed in production

Checked against the live scraper database before shipping:

```
30,641 rows   /   30,155 distinct links
485 links duplicated across 971 rows, one of them three times
399 of the duplicated rows never resolved to an anime
0 links mapping to two different anime
```

So the migration **collapses duplicates first**, keeping the row that resolves to an anime over one that doesn't, then most recently updated, then highest id.

## Why the duplicates exist — and why deduplicating alone wouldn't hold

The cause is in the same file. `upsert()` matched on `name + type` first and only fell back to `link`:

```js
savedLink = await this.findOne({ name, type })              // primary
if (!savedLink) savedLink = await this.findOne({ where: { link } })   // fallback
```

A retitled entry misses the name lookup, so it inserts. MAL lists anime 2048 as three different titles, and production has all three:

```
"Kikou Ryouhei Merowlink"   → 927b462b…
"Kikou Ryouhei Mellowlink"  → (null)
"Armor Hunter Mellowlink"   → 927b462b…
```

The lookup order is now inverted — **the link is the identity, the name is a label on it**. Without that, deduplicating is pointless: the scraper rebuilds the duplicates on its next pass, and now against a unique index that refuses them.

(The two lookups also used different call shapes — one a bare object, one `{ where: … }`. Both are `{ where: … }` now.)

`tsc --noEmit` clean.

## Next

Step 2 is the entity and the resolution helpers that take a `RECORD_TYPE`; step 3 is the `work` table itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)