### PR TITLE
feat: resolve myanimelist links to any record type, not just anime

### DIFF
--- a/src/modules/myanimelist/repository/interface.ts
+++ b/src/modules/myanimelist/repository/interface.ts
@@ -4,6 +4,10 @@ export interface IMyanimelist {
   readonly name: string
   readonly link: string
   readonly animeId: string
+  // The generic target. animeId is kept beside it until the column is dropped,
+  // so a deploy of this code and the migration that fills record_id do not have
+  // to happen together.
+  readonly recordId: string
   readonly updatedAt: Date
 }
 

--- a/src/modules/myanimelist/repository/myanimelist.entity.ts
+++ b/src/modules/myanimelist/repository/myanimelist.entity.ts
@@ -24,6 +24,14 @@ export class MyanimelistLinks {
   @Column({ name: 'anime_id', nullable: true, type: 'varchar', length: 36 })
   animeId: string
 
+  // What this link points at, whatever kind of record that is. `type` says
+  // which table to read it from; together they are the resolution key.
+  //
+  // anime_id stays for now so this column and the code that fills it can deploy
+  // separately. It is the one to drop once nothing reads it.
+  @Column({ name: 'record_id', nullable: true, type: 'varchar', length: 36 })
+  recordId: string
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date
 

--- a/src/modules/myanimelist/repository/myanimelist.repository.ts
+++ b/src/modules/myanimelist/repository/myanimelist.repository.ts
@@ -1,41 +1,59 @@
-import { Between, EntityRepository, LessThanOrEqual, Repository } from 'typeorm'
+import { Between, EntityRepository, Repository } from 'typeorm'
 import * as _ from 'lodash'
 import { IMyanimelist, RECORD_TYPE } from './interface'
 import { MyanimelistLinks } from './myanimelist.entity'
-import {da} from "date-fns/locale";
 
 @EntityRepository(MyanimelistLinks)
 export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
-  public async findOneById(id: number): Promise<IMyanimelist> {
-    const item: MyanimelistLinks = await this.findOne({
-      where: { id },
-    })
-
-    return item
+  // The projection was written out at every return site, which is how a column
+  // gets added to the entity and silently missed by half the reads.
+  private toInterface(link: MyanimelistLinks): IMyanimelist {
+    return link
       ? {
-          id: item.id,
-          name: item.name,
-          type: item.type,
-          link: item.link,
-          animeId: item.animeId,
-          updatedAt: item.updatedAt,
+          id: link.id,
+          name: link.name,
+          type: link.type,
+          link: link.link,
+          animeId: link.animeId,
+          recordId: link.recordId ?? link.animeId,
+          updatedAt: link.updatedAt,
         }
       : null
   }
 
-  async findOneByName(name: string): Promise<IMyanimelist> {
-    const item: MyanimelistLinks = await this.findOne({ where: { name } })
+  public async findOneById(id: number): Promise<IMyanimelist> {
+    return this.toInterface(await this.findOne({ where: { id } }))
+  }
 
-    return item
-      ? {
-          id: item.id,
-          name: item.name,
-          type: item.type,
-          link: item.link,
-          animeId: item.animeId,
-          updatedAt: item.updatedAt,
-        }
-      : null
+  async findOneByName(name: string): Promise<IMyanimelist> {
+    return this.toInterface(await this.findOne({ where: { name } }))
+  }
+
+  // "Given this MAL URL, what is our id" -- the question the scraper asks for
+  // every related entry on every page it parses. The link is unique, so this is
+  // a single index lookup and the answer carries its own type: a link to a manga
+  // resolves to a work id, one to an anime resolves to an anime id.
+  //
+  // Returns null when the URL has never been seen, which is not an error. It is
+  // the normal case for a relation to something not scraped yet, and the reason
+  // the link is stored unresolved rather than dropped.
+  async resolveByLink(
+    link: string,
+  ): Promise<{ type: RECORD_TYPE; recordId: string } | null> {
+    const found: MyanimelistLinks = await this.findOne({ where: { link } })
+    if (!found) {
+      return null
+    }
+
+    const recordId: string = found.recordId ?? found.animeId
+    return recordId ? { type: found.type, recordId } : null
+  }
+
+  // Every link of one kind. getAllAnime is this with the type fixed.
+  async findAllByType(type: RECORD_TYPE): Promise<IMyanimelist[]> {
+    const links: MyanimelistLinks[] = await this.find({ where: { type } })
+
+    return links.map((link: MyanimelistLinks) => this.toInterface(link))
   }
 
   public async upsert(body: Partial<MyanimelistLinks>): Promise<IMyanimelist> {
@@ -50,6 +68,14 @@ export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
       body,
       nullFields,
     ) as MyanimelistLinks
+
+    // Callers that only know about anime still pass animeId. Mirror it so
+    // record_id is populated from now on and the backfill does not have to be
+    // repeated when anime_id is finally dropped.
+    if (cleanBody.animeId && !cleanBody.recordId) {
+      cleanBody.recordId = cleanBody.animeId
+    }
+
     // Match on the link first.
     //
     // This matched on name+type first and fell back to the link, which made a
@@ -74,15 +100,8 @@ export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
 
     if (savedLink) {
       await this.update({ id: savedLink.id }, cleanBody)
-      const link = { ...savedLink, ...cleanBody }
-      return {
-        id: link.id,
-        name: link.name,
-        type: link.type,
-        link: link.link,
-        animeId: link.animeId,
-        updatedAt: link.updatedAt,
-      }
+
+      return this.toInterface({ ...savedLink, ...cleanBody })
     }
 
     // eslint-disable-next-line
@@ -92,30 +111,12 @@ export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
     cleanBody = null
     nullFields = null
     savedLink = null
-    return {
-      id: saved.id,
-      name: saved.name,
-      type: saved.type,
-      link: saved.link,
-      animeId: saved.animeId,
-      updatedAt: saved.updatedAt,
-    }
+
+    return this.toInterface(saved)
   }
 
   async getAllAnime(): Promise<IMyanimelist[]> {
-    const links: MyanimelistLinks[] = await this.find({
-      where: {
-        type: RECORD_TYPE.Anime,
-      },
-    })
-    return links.map((link: MyanimelistLinks) => ({
-      id: link.id,
-      name: link.name,
-      type: link.type,
-      link: link.link,
-      animeId: link.animeId,
-      updatedAt: link.updatedAt,
-    }))
+    return this.findAllByType(RECORD_TYPE.Anime)
   }
 
   async getAllNewAnime(days: number = 1): Promise<IMyanimelist[]> {
@@ -127,7 +128,6 @@ export class MyanimelistlinkRepository extends Repository<MyanimelistLinks> {
     const yesterday = new Date(
       new Date(today).setDate(today.getDate() - days),
     ).toISOString()
-console.log(yesterday, today.toISOString())
 
     const links: MyanimelistLinks[] = await this.find({
       where: {
@@ -136,14 +136,7 @@ console.log(yesterday, today.toISOString())
         createdAt: Between(yesterday, today.toISOString()),
       },
     })
-    console.log(links)
-    return links.map((link: MyanimelistLinks) => ({
-      id: link.id,
-      name: link.name,
-      type: link.type,
-      link: link.link,
-      animeId: link.animeId,
-      updatedAt: link.updatedAt,
-    }))
+
+    return links.map((link: MyanimelistLinks) => this.toInterface(link))
   }
 }


### PR DESCRIPTION
Step 2 of `docs/manga-and-works.md`. #13 added `record_id` to the table; this is the code that reads and writes it.

## Why

`RECORD_TYPE` has carried `Manga`, `Character`, `Staff`, `Studio` and `User` since the table was created, but `anime_id` was the only foreign key — so every type except `Anime` had a label to declare and nowhere to point. A manga link could not be stored.

## What

- **`MyanimelistLinks.recordId`** — added *beside* `animeId`, not instead of it, so this deploys independently of dropping the old column.
- **`upsert` mirrors `animeId` → `recordId`** when a caller supplies only the former (every existing caller does). The column keeps filling from now on, so the backfill never has to run twice, and no call site needed changing.
- **`resolveByLink(link)`** → `{ type, recordId } | null` — the lookup the scraper actually performs: *given this MAL URL, what is our id and what kind of record is it.* Backed by the unique index from #13, so it is a single index lookup. Returns `null` for an unseen URL, which is normal rather than an error: recording a relation to something not yet scraped is the point of the table.
- **`findAllByType(type)`** — generalises `getAllAnime`, which now delegates to it.
- **One projection mapper.** The `IMyanimelist` projection was written out at all six return sites; that duplication is precisely how a column gets added to the entity and missed by half the reads.

## Verified

`tsc --noEmit` and `yarn build` both clean. Confirmed against the prod scraper DB that #13's migration is applied (`record_id` present, both indexes created, 30,155 rows with total == distinct links).

No tests added — this repo has no spec files and CI runs none, so adding a suite here would be a new convention rather than following one.

## Next

Steps 3 and 4: the `work` table and `anime.source_work_id`.