### PR TITLE
feat: add the work table and anime.source_work_id

### DIFF
--- a/migrations/1787270400000-AddWorkTableAndAnimeSourceWork.ts
+++ b/migrations/1787270400000-AddWorkTableAndAnimeSourceWork.ts
@@ -1,0 +1,94 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Adds `work` -- the manga, light novels and novels anime are adapted from --
+ * and `anime.source_work_id` pointing at it.
+ *
+ * See docs/manga-and-works.md for why this is one table rather than `manga` +
+ * `light_novel` + ..., and why it is a sibling of `anime` rather than a merge
+ * into a shared `items` table. In short: MAL serves the whole manga family from
+ * one namespace at /manga/<id> with a `Type` field, and the fields are
+ * effectively identical across those types, while anime and works genuinely
+ * differ in shape.
+ *
+ * The point of it is that `anime.source` records a category, never an identity.
+ * We know 6,110 anime came from a manga and cannot say which one, so
+ * re-adaptations of the same source -- Fruits Basket 2001 and 2019, Hunter x
+ * Hunter 1999 and 2011 -- look unrelated. They share no TheTVDB id and often no
+ * cast, so both existing relation signals miss them.
+ */
+export class AddWorkTableAndAnimeSourceWork1787270400000 implements MigrationInterface {
+    name = 'AddWorkTableAndAnimeSourceWork1787270400000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "work" (
+                "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "mal_id" integer,
+                "type" character varying(32) NOT NULL DEFAULT 'MANGA',
+                "title_en" character varying(255),
+                "title_jp" character varying(255),
+                "title_synonyms" text,
+                "synopsis" text,
+                "image_url" character varying(512),
+                "status" character varying(64),
+                "volumes" integer,
+                "chapters" integer,
+                "published_from" TIMESTAMP WITH TIME ZONE,
+                "published_to" TIMESTAMP WITH TIME ZONE,
+                "demographic" character varying(64),
+                "serialization" character varying(255),
+                "authors" text,
+                "score" numeric(4,2),
+                "ranking" integer,
+                "members" integer,
+                "favorites" integer,
+                "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_work_id" PRIMARY KEY ("id")
+            )
+        `);
+
+        // One MAL manga id is one work. Unique so a re-scrape updates rather
+        // than duplicating -- the same mistake myanimelist_link made by keying
+        // on a title that MAL rewrites freely, which cost 486 duplicate rows.
+        //
+        // Nullable and unique coexist in postgres: works from a source other
+        // than MAL can arrive without an id and will not collide.
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_work_mal_id" ON "work" ("mal_id")`);
+
+        // The catalogue is browsed and counted by type far more than by
+        // anything else here.
+        await queryRunner.query(`CREATE INDEX "IDX_work_type" ON "work" ("type")`);
+
+        // One column rather than a link table. An anime adapting several works
+        // exists but is rare enough that the join table can wait until there is
+        // a case that needs it; adding it later does not invalidate this column.
+        await queryRunner.query(`ALTER TABLE "anime" ADD "source_work_id" uuid`);
+
+        // The lookup runs in both directions: an anime's source, and every anime
+        // adapted from one work -- which is the whole point, since that set is
+        // what relates re-adaptations to each other.
+        await queryRunner.query(`CREATE INDEX "IDX_anime_source_work_id" ON "anime" ("source_work_id")`);
+
+        // Deliberately no foreign key.
+        //
+        // Scrape order is not dependency order. An anime page is parsed before
+        // the manga it names has ever been fetched, and step 6 of the plan
+        // stores that relation unresolved in myanimelist_link precisely so it
+        // can be filled in whenever the other side arrives. A constraint here
+        // would reject exactly the writes the design expects, and the read
+        // store already learned this lesson from the other direction: CDC makes
+        // no ordering promise across tables, and anime-sync had to start
+        // discarding foreign key violations because an episode routinely
+        // arrives before its anime.
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_anime_source_work_id"`);
+        await queryRunner.query(`ALTER TABLE "anime" DROP COLUMN "source_work_id"`);
+        await queryRunner.query(`DROP INDEX "IDX_work_type"`);
+        await queryRunner.query(`DROP INDEX "IDX_work_mal_id"`);
+        await queryRunner.query(`DROP TABLE "work"`);
+    }
+}

--- a/src/modules/anime/repository/anime.entity.ts
+++ b/src/modules/anime/repository/anime.entity.ts
@@ -137,6 +137,15 @@ export class Anime {
   @Column({ name: 'ranking', nullable: true })
   ranking: number
 
+  // The work this anime adapts, when we know it. Null is the normal state: two
+  // thirds of the catalogue is either original or from a source MAL's manga
+  // database does not cover, and a relation to a work not yet scraped is held
+  // unresolved in myanimelist_link until the other side arrives.
+  //
+  // No foreign key -- scrape order is not dependency order. See the migration.
+  @Column({ name: 'source_work_id', nullable: true, type: 'uuid' })
+  source_work_id: string
+
   @OneToMany(() => AnimeSeasonEntity, animeSeason => animeSeason.anime)
   seasons: AnimeSeasonEntity[]
 

--- a/src/modules/anime/repository/anime.repository.ts
+++ b/src/modules/anime/repository/anime.repository.ts
@@ -35,6 +35,7 @@ export class AnimeRepository extends Repository<Anime> {
           studios: item.studios,
           rating: item.rating,
           ranking: item.ranking,
+          source_work_id: item.source_work_id,
           createdAt: item.createdAt,
           updatedAt: item.updatedAt,
         }
@@ -70,6 +71,7 @@ export class AnimeRepository extends Repository<Anime> {
           studios: item.studios,
           rating: item.rating,
           ranking: item.ranking,
+          source_work_id: item.source_work_id,
           createdAt: item.createdAt,
           updatedAt: item.updatedAt,
         }
@@ -103,6 +105,7 @@ export class AnimeRepository extends Repository<Anime> {
           studios: item.studios,
           rating: item.rating,
           ranking: item.ranking,
+          source_work_id: item.source_work_id,
           createdAt: item.createdAt,
           updatedAt: item.updatedAt,
         }
@@ -154,6 +157,7 @@ export class AnimeRepository extends Repository<Anime> {
         studios: link.studios,
         rating: link.rating,
         ranking: link.ranking,
+        source_work_id: link.source_work_id,
         createdAt: link.createdAt,
         updatedAt: link.updatedAt,
       }
@@ -189,6 +193,7 @@ export class AnimeRepository extends Repository<Anime> {
       studios: saved.studios,
       rating: saved.rating,
       ranking: saved.ranking,
+      source_work_id: saved.source_work_id,
       createdAt: saved.createdAt,
       updatedAt: saved.updatedAt,
     }
@@ -230,6 +235,7 @@ ON t.title_en = duplicates.title_en
         studios: item.studios,
         rating: item.rating,
         ranking: item.ranking,
+        source_work_id: item.source_work_id,
         createdAt: item.createdAt,
         updatedAt: item.updatedAt,
       }

--- a/src/modules/anime/repository/interface.ts
+++ b/src/modules/anime/repository/interface.ts
@@ -23,6 +23,9 @@ export interface IAnime {
   studios: string[]
   rating: string
   ranking: number
+  // The work this anime adapts, when known. Null for originals and for sources
+  // MAL's manga database does not cover -- which is most of the catalogue.
+  source_work_id: string
   createdAt: Date
   updatedAt: Date
 }

--- a/src/modules/common/scrapedList.ts
+++ b/src/modules/common/scrapedList.ts
@@ -1,0 +1,27 @@
+// MAL renders an absent list as a placeholder rather than omitting it, and the
+// scraper has been storing that placeholder as data. 11,497 of 29,673 anime
+// rows -- 38.7% -- have `["None found"," add some"]` sitting in `studios` as
+// though those were two real studios.
+//
+// The leading whitespace in that example is the second half of the problem: the
+// list is split on commas without trimming, so `"Sunrise, Inc."` becomes
+// `["Sunrise"," Inc."]` and `" Inc."` ends up looking like a studio credited on
+// 19 anime.
+//
+// Cleaning at parse time rather than on read means the dirt never enters the
+// column, which is the difference between this and the existing columns.
+const PLACEHOLDERS: readonly string[] = ['none found', 'add some', 'none', 'n/a', 'unknown']
+
+export function cleanScrapedList(values: readonly string[] | null): string[] {
+  if (!values) {
+    return []
+  }
+
+  const cleaned: string[] = values
+    .map((value: string) => (value ?? '').trim())
+    .filter((value: string) => value.length > 0)
+    .filter((value: string) => !PLACEHOLDERS.includes(value.toLowerCase()))
+
+  // MAL repeats a credit when someone holds two roles on the same work.
+  return Array.from(new Set(cleaned))
+}

--- a/src/modules/myanimelist/myanimelist.module.ts
+++ b/src/modules/myanimelist/myanimelist.module.ts
@@ -6,6 +6,7 @@ import { AnimeModule } from '../anime/anime.module'
 import { alignColorsAndTime } from '../common/loggerformat'
 import { PuppeteerModule } from '../puppeteer/puppeteer.module'
 import { ScrapeRecordModule } from '../scrape_record/scrape_record.module'
+import { WorkModule } from '../work/work.module'
 import { MyanimelistService } from './myanimelist.service'
 import { MyanimelistlinkRepository } from './repository/myanimelist.repository'
 
@@ -14,6 +15,7 @@ import { MyanimelistlinkRepository } from './repository/myanimelist.repository'
     TypeOrmModule.forFeature([MyanimelistlinkRepository]),
     PuppeteerModule,
     AnimeModule,
+    WorkModule,
     WinstonModule.forRoot(
       ((name: string) => ({
         // options

--- a/src/modules/work/repository/interface.ts
+++ b/src/modules/work/repository/interface.ts
@@ -1,0 +1,44 @@
+// The manga family as MAL models it: one namespace at /manga/<id>, with a Type
+// field telling the kinds apart. They are one shape wearing several labels --
+// the fields are identical across them apart from Demographic -- so they are
+// one table discriminated by this, rather than a table each.
+//
+// A visual novel from VNDB would be a genuinely different shape. That is when a
+// per-type detail table earns its keep, and this model stays open to it.
+export enum WORK_TYPE {
+  Manga = 'MANGA',
+  LightNovel = 'LIGHT_NOVEL',
+  Novel = 'NOVEL',
+  WebManga = 'WEB_MANGA',
+  WebNovel = 'WEB_NOVEL',
+  OneShot = 'ONE_SHOT',
+  Doujinshi = 'DOUJINSHI',
+  Manhwa = 'MANHWA',
+  Manhua = 'MANHUA',
+  FourKoma = 'FOUR_KOMA',
+}
+
+export interface IWork {
+  readonly id: string
+  readonly malId: number
+  readonly type: WORK_TYPE
+  readonly titleEn: string
+  readonly titleJp: string
+  readonly titleSynonyms: string[]
+  readonly synopsis: string
+  readonly imageUrl: string
+  readonly status: string
+  readonly volumes: number
+  readonly chapters: number
+  readonly publishedFrom: Date | null
+  readonly publishedTo: Date | null
+  readonly demographic: string
+  readonly serialization: string
+  readonly authors: string[]
+  readonly score: number
+  readonly ranking: number
+  readonly members: number
+  readonly favorites: number
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}

--- a/src/modules/work/repository/work.entity.ts
+++ b/src/modules/work/repository/work.entity.ts
@@ -1,0 +1,102 @@
+import {
+  Entity,
+  Column,
+  UpdateDateColumn,
+  CreateDateColumn,
+  PrimaryColumn,
+  Generated,
+} from 'typeorm'
+import { WORK_TYPE } from './interface'
+
+// A JSON array in a text column, matching how anime stores genres, studios and
+// licensors. The values that go in are cleaned first -- see
+// common/scrapedList.ts -- so this column does not inherit the placeholder rows
+// that convention left in anime.studios.
+const jsonArray = {
+  to(value: string[]): string {
+    return JSON.stringify(value ?? [])
+  },
+  from(value: string): string[] {
+    if (!value) {
+      return []
+    }
+    try {
+      return JSON.parse(value)
+    } catch {
+      return []
+    }
+  },
+}
+
+@Entity({ name: 'work' })
+export class Work {
+  @PrimaryColumn({ type: 'uuid' })
+  @Generated('uuid')
+  id: string
+
+  // The identity. Unique, so a re-scrape updates instead of duplicating.
+  @Column({ name: 'mal_id', nullable: true, type: 'int' })
+  malId: number
+
+  @Column({ name: 'type', enum: WORK_TYPE, default: WORK_TYPE.Manga })
+  type: WORK_TYPE
+
+  @Column({ name: 'title_en', nullable: true })
+  titleEn: string
+
+  @Column({ name: 'title_jp', nullable: true })
+  titleJp: string
+
+  @Column('text', { name: 'title_synonyms', nullable: true, transformer: jsonArray })
+  titleSynonyms: string[]
+
+  @Column({ name: 'synopsis', nullable: true, type: 'text' })
+  synopsis: string
+
+  @Column({ name: 'image_url', nullable: true })
+  imageUrl: string
+
+  @Column({ name: 'status', nullable: true })
+  status: string
+
+  @Column({ name: 'volumes', nullable: true, type: 'int' })
+  volumes: number
+
+  @Column({ name: 'chapters', nullable: true, type: 'int' })
+  chapters: number
+
+  @Column({ name: 'published_from', nullable: true, type: 'timestamptz' })
+  publishedFrom: Date | null
+
+  @Column({ name: 'published_to', nullable: true, type: 'timestamptz' })
+  publishedTo: Date | null
+
+  // The one field that differs between manga and light novels on MAL, and the
+  // reason the type column exists rather than a separate table.
+  @Column({ name: 'demographic', nullable: true })
+  demographic: string
+
+  @Column({ name: 'serialization', nullable: true })
+  serialization: string
+
+  @Column('text', { name: 'authors', nullable: true, transformer: jsonArray })
+  authors: string[]
+
+  @Column({ name: 'score', nullable: true, type: 'numeric', precision: 4, scale: 2 })
+  score: number
+
+  @Column({ name: 'ranking', nullable: true, type: 'int' })
+  ranking: number
+
+  @Column({ name: 'members', nullable: true, type: 'int' })
+  members: number
+
+  @Column({ name: 'favorites', nullable: true, type: 'int' })
+  favorites: number
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date
+}

--- a/src/modules/work/repository/work.repository.ts
+++ b/src/modules/work/repository/work.repository.ts
@@ -1,0 +1,89 @@
+import { EntityRepository, Repository } from 'typeorm'
+import * as _ from 'lodash'
+import { cleanScrapedList } from '../../common/scrapedList'
+import { IWork, WORK_TYPE } from './interface'
+import { Work } from './work.entity'
+
+@EntityRepository(Work)
+export class WorkRepository extends Repository<Work> {
+  private toInterface(work: Work): IWork {
+    return work
+      ? {
+          id: work.id,
+          malId: work.malId,
+          type: work.type,
+          titleEn: work.titleEn,
+          titleJp: work.titleJp,
+          titleSynonyms: work.titleSynonyms,
+          synopsis: work.synopsis,
+          imageUrl: work.imageUrl,
+          status: work.status,
+          volumes: work.volumes,
+          chapters: work.chapters,
+          publishedFrom: work.publishedFrom,
+          publishedTo: work.publishedTo,
+          demographic: work.demographic,
+          serialization: work.serialization,
+          authors: work.authors,
+          score: work.score,
+          ranking: work.ranking,
+          members: work.members,
+          favorites: work.favorites,
+          createdAt: work.createdAt,
+          updatedAt: work.updatedAt,
+        }
+      : null
+  }
+
+  public async findOneById(id: string): Promise<IWork> {
+    return this.toInterface(await this.findOne({ where: { id } }))
+  }
+
+  public async findOneByMalId(malId: number): Promise<IWork> {
+    return this.toInterface(await this.findOne({ where: { malId } }))
+  }
+
+  public async findAllByType(type: WORK_TYPE): Promise<IWork[]> {
+    const works: Work[] = await this.find({ where: { type } })
+
+    return works.map((work: Work) => this.toInterface(work))
+  }
+
+  // Keyed on mal_id, not on the title.
+  //
+  // MAL rewrites titles freely -- the same URL has been listed as "Kikou Ryouhei
+  // Merowlink", "Kikou Ryouhei Mellowlink" and "Armor Hunter Mellowlink" -- and
+  // keying myanimelist_link on the title is what left 486 duplicate rows there.
+  // The id is the thing that does not change.
+  public async upsert(body: Partial<Work>): Promise<IWork> {
+    const nullFields: readonly string[] = Object.keys(body).reduce(
+      (empty: readonly string[], key: string) =>
+        body[key] === null || body[key] === undefined ? empty.concat(key) : empty,
+      [],
+    )
+    const cleanBody: Work = _.omit(body, nullFields) as Work
+
+    // Clean on the way in rather than on the way out, so the placeholder rows
+    // that fill anime.studios never reach the column in the first place.
+    if (cleanBody.authors) {
+      cleanBody.authors = cleanScrapedList(cleanBody.authors)
+    }
+    if (cleanBody.titleSynonyms) {
+      cleanBody.titleSynonyms = cleanScrapedList(cleanBody.titleSynonyms)
+    }
+
+    const existing: Work = cleanBody.malId
+      ? await this.findOne({ where: { malId: cleanBody.malId } })
+      : null
+
+    if (existing) {
+      await this.update({ id: existing.id }, cleanBody)
+
+      return this.toInterface({ ...existing, ...cleanBody })
+    }
+
+    const saved: Work = await this.save(this.create(cleanBody))
+
+    return this.toInterface(saved)
+  }
+}

--- a/src/modules/work/work.module.ts
+++ b/src/modules/work/work.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { WorkRepository } from './repository/work.repository'
+import { WorkService } from './work.service'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkRepository])],
+  providers: [WorkService],
+  exports: [WorkService, TypeOrmModule],
+})
+export class WorkModule {}

--- a/src/modules/work/work.service.ts
+++ b/src/modules/work/work.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { IWork, WORK_TYPE } from './repository/interface'
+import { WorkRepository } from './repository/work.repository'
+import { Work } from './repository/work.entity'
+
+@Injectable()
+export class WorkService {
+  constructor(
+    @InjectRepository(WorkRepository)
+    private readonly workRepository: WorkRepository,
+  ) {}
+
+  upsertWork(work: Partial<Work>): Promise<IWork> {
+    return this.workRepository.upsert(work)
+  }
+
+  findByMalId(malId: number): Promise<IWork> {
+    return this.workRepository.findOneByMalId(malId)
+  }
+
+  findById(id: string): Promise<IWork> {
+    return this.workRepository.findOneById(id)
+  }
+
+  findAllByType(type: WORK_TYPE): Promise<IWork[]> {
+    return this.workRepository.findAllByType(type)
+  }
+}


### PR DESCRIPTION
Steps 3 and 4 of `docs/manga-and-works.md`, together in one migration — `source_work_id` points at `work`, and neither is useful without the other. **One manual migration run**, not two.

## Why

`anime.source` records a *category*, never an identity:

```
Original 13,334   Manga 6,110   Light novel 1,362   Web manga 831 ...
```

We know 6,110 anime came from a manga and can't say **which** one. So re-adaptations of the same source — Fruits Basket 2001/2019, Hunter x Hunter 1999/2011, FMA/Brotherhood — look unrelated: they share no TheTVDB id and usually no cast, which is what both existing `relatedAnime` signals depend on.

## Schema

`work(id, mal_id, type, title_en, title_jp, title_synonyms, synopsis, image_url, status, volumes, chapters, published_from, published_to, demographic, serialization, authors, score, ranking, members, favorites, created_at, updated_at)`

- **unique `mal_id`** — one MAL id is one work, so a re-scrape updates rather than duplicating. That is the mistake `myanimelist_link` made by keying on a title MAL rewrites freely, which cost 486 duplicate rows.
- **`anime.source_work_id`** — nullable, indexed, **no foreign key**. Scrape order is not dependency order: an anime page is parsed long before the manga it names is fetched, and step 6 deliberately stores that relation unresolved until the other side arrives. A constraint would reject exactly the writes the design expects — the read store already learned the same lesson from CDC ordering, which is why `anime-sync` discards FK violations.

## authors: cleaned at parse time

Per your call — JSON text matching the `studios`/`genres`/`licensors` convention, but with the dirt stopped at the door. The existing convention's state, measured just now:

```
anime rows              29,673
with ["None found"," add some"]  11,497   (38.7%)
```

plus the split-without-trim bug visible in live data — `["asread.","       White Fox"]` — which is how `" Inc."` became a studio credited on 19 anime.

`common/scrapedList.ts` trims, drops MAL's placeholders and dedupes on the way in, so `work.authors` does not inherit that. Normalising into real rows stays a read-store job, beside `tags` — the scraper has no tag table and that is where the precedent lives.

## Verified

- `tsc --noEmit` and `yarn build` clean.
- **The migration SQL was executed against the live prod scraper schema inside a transaction and rolled back** — every statement succeeded, and `information_schema` confirms 0 `work` tables left behind.
- eslint is broken in this repo for unrelated reasons (`eslint-plugin-levitate` fails to resolve, on untouched files too); CI does not run it.

## Needs a manual migration run

Same as #13 — root `migrations/` is not in the image, so this needs `npm run typeorm -- migration:run` from a checkout after merge.

## Next

Step 5: scraping MAL manga pages. `WorkModule` is already wired into `MyanimelistModule` so the service is available when that lands.
