### PR TITLE
feat: scrape MyAnimeList manga pages into works

### DIFF
--- a/src/modules/commander/commander.module.ts
+++ b/src/modules/commander/commander.module.ts
@@ -9,6 +9,7 @@ import { DeduplicateModule } from '../deduplicate/deduplicate.module'
 import { ScraperCommand } from './scrape.command'
 import { CollectCommand } from './collect.command'
 import { NewCommand } from './new.command'
+import { MangaCommand } from './manga.command'
 import { SeasonalCommand } from './seasonal.command'
 import { ValidateCommand } from './validate.command'
 
@@ -55,6 +56,6 @@ import { DeduplicateCommand } from './deduplicate.command'
     }),
   ],
   controllers: [],
-  providers: [NewCommand, ScraperCommand, CollectCommand, DeduplicateCommand, SeasonalCommand, ValidateCommand],
+  providers: [NewCommand, MangaCommand, ScraperCommand, CollectCommand, DeduplicateCommand, SeasonalCommand, ValidateCommand],
 })
 export class ScraperCommandModule {}

--- a/src/modules/commander/manga.command.ts
+++ b/src/modules/commander/manga.command.ts
@@ -1,0 +1,84 @@
+import * as path from 'path'
+import * as fs from 'fs'
+import { Inject } from '@nestjs/common'
+import { CommandRunner, Option, SubCommand } from 'nest-commander'
+import { Logger } from 'winston'
+import { ScraperService } from '../scraper/scraper.service'
+
+interface MangaCommandOptions {
+  msite: string
+  mlimit?: number
+  mheadless?: boolean
+  file?: string
+}
+
+// `scrape manga` -- the manga, light novels and novels anime are adapted from.
+//
+// URLs are given rather than discovered. MAL's manga database is far larger
+// than the part of it we care about, and the part we care about is defined by
+// what something adapts, which the anime pages already tell us.
+@SubCommand({
+  name: 'manga',
+  description: 'Scrape MyAnimeList manga pages into works',
+})
+export class MangaCommand extends CommandRunner {
+  constructor(
+    @Inject('winston')
+    private readonly logger: Logger,
+    private readonly scapperService: ScraperService,
+  ) {
+    super()
+  }
+
+  async run(
+    passedParam: string[],
+    options?: MangaCommandOptions,
+  ): Promise<void> {
+    let urls: string[] = null
+    if (options?.file !== undefined && options?.file !== null) {
+      const contents: string = fs.readFileSync(
+        path.resolve(process.cwd(), options.file),
+        'utf8',
+      )
+      urls = JSON.parse(contents)
+    }
+
+    const site: string = options?.msite || 'myanimelist'
+    if (site !== 'myanimelist') {
+      this.logger.error(`Site ${site} has no manga pages to scrape`)
+
+      return
+    }
+
+    await this.scapperService.scrapeMyAnimeListManga(
+      passedParam,
+      options?.mlimit,
+      !!options?.mheadless,
+      urls,
+    )
+  }
+
+  @Option({
+    flags: '-ms, --msite [site]',
+    description: 'What site to scrape (only myanimelist)',
+  })
+  getSite(val: string): string {
+    return val
+  }
+
+  @Option({
+    flags: '-ml, --mlimit [limit]',
+    description: 'How many pages to scrape concurrently',
+  })
+  getLimit(val: string): number {
+    return parseInt(val, 10)
+  }
+
+  @Option({
+    flags: '-mh, --mheadless',
+    description: 'Run headless',
+  })
+  getHeadless(): boolean {
+    return true
+  }
+}

--- a/src/modules/commander/scrape.command.ts
+++ b/src/modules/commander/scrape.command.ts
@@ -5,6 +5,7 @@ import { Command, CommandRunner, Option } from 'nest-commander'
 import { Logger } from 'winston'
 import { ScraperService } from '../scraper/scraper.service'
 import { NewCommand } from './new.command'
+import { MangaCommand } from './manga.command'
 
 interface BasicCommandOptions {
   site: string
@@ -27,7 +28,7 @@ export const SCRAPE_DATA_TYPES = ['main', 'characters', 'episodes'] as const
   name: 'scrape',
   description: 'A parameter parse',
   // @ts-ignore
-  subCommands: [NewCommand],
+  subCommands: [NewCommand, MangaCommand],
 })
 export class ScraperCommand extends CommandRunner {
   constructor(

--- a/src/modules/myanimelist/mangaPage.ts
+++ b/src/modules/myanimelist/mangaPage.ts
@@ -1,0 +1,141 @@
+import { WORK_TYPE } from '../work/repository/interface'
+
+// MAL's sidebar, read as structure rather than as text.
+//
+// Each row is a label in a <span> followed by its value, and where the value is
+// a set of things -- authors, genres, themes -- each one is its own <a>. Reading
+// the anchors is the difference between a correct list and the bug that already
+// lives in anime.studios: splitting the row's text on commas turns
+// "Sunrise, Inc." into ["Sunrise", " Inc."], and MAL writes authors as
+// "Yukimura, Makoto (Story & Art)" -- surname first, comma inside the name.
+// Every author would split in half.
+export interface SidebarRow {
+  readonly label: string
+  readonly text: string
+  readonly links: string[]
+}
+
+// Runs in the page. Returns one entry per sidebar row.
+export function readSidebar(): SidebarRow[] {
+  const rows = Array.from(document.querySelectorAll('#content td .spaceit_pad'))
+
+  return rows.map((row: Element) => {
+    const span: Element | null = row.querySelector('span')
+    const label: string = (span?.textContent || '')
+      .replace(/:/g, '')
+      .trim()
+      .toLowerCase()
+
+    const anchors: Element[] = Array.from(row.querySelectorAll('a'))
+
+    return {
+      label,
+      text: (row.textContent || '').replace(span?.textContent || '', '').trim(),
+      links: anchors.map((a: Element) => (a.textContent || '').trim()),
+    }
+  })
+}
+
+export function rowText(rows: SidebarRow[], label: string): string | null {
+  const row: SidebarRow = rows.find((r: SidebarRow) => r.label === label)
+
+  return row && row.text ? row.text : null
+}
+
+// Prefer the anchors; fall back to the raw text only when the row has none,
+// which is how MAL renders a single unlinked value.
+export function rowList(rows: SidebarRow[], label: string): string[] {
+  const row: SidebarRow = rows.find((r: SidebarRow) => r.label === label)
+  if (!row) {
+    return []
+  }
+  if (row.links.length > 0) {
+    return row.links
+  }
+
+  return row.text ? [row.text] : []
+}
+
+// "1,234,567" -> 1234567, "Unknown" -> null.
+export function malNumber(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+  const digits: string = value.replace(/[^0-9.]/g, '')
+  if (!digits) {
+    return null
+  }
+  const parsed: number = Number(digits)
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+// MAL's Type on a /manga/ page. The values are the manga family; anything
+// unrecognised is stored as MANGA rather than dropped, because a new label is
+// far more likely than a genuinely new shape and losing the row helps nobody.
+const TYPES: ReadonlyMap<string, WORK_TYPE> = new Map([
+  ['manga', WORK_TYPE.Manga],
+  ['light novel', WORK_TYPE.LightNovel],
+  ['novel', WORK_TYPE.Novel],
+  ['web manga', WORK_TYPE.WebManga],
+  ['web novel', WORK_TYPE.WebNovel],
+  ['one-shot', WORK_TYPE.OneShot],
+  ['oneshot', WORK_TYPE.OneShot],
+  ['doujinshi', WORK_TYPE.Doujinshi],
+  ['manhwa', WORK_TYPE.Manhwa],
+  ['manhua', WORK_TYPE.Manhua],
+  ['4-koma manga', WORK_TYPE.FourKoma],
+  ['4-koma', WORK_TYPE.FourKoma],
+])
+
+export function toWorkType(value: string | null): WORK_TYPE {
+  return TYPES.get((value || '').trim().toLowerCase()) || WORK_TYPE.Manga
+}
+
+// /manga/<id>/<slug> -> <id>
+export function malIdFromUrl(url: string): number | null {
+  const match: RegExpMatchArray | null = url.match(/\/manga\/(\d+)/)
+
+  return match ? parseInt(match[1], 10) : null
+}
+
+// MAL writes Published as "Aug 13, 2005 to Jul 8, 2021", and for anything still
+// running as "Aug 13, 2005 to ?". Precision varies: a year alone, or a month and
+// year, are both common on older entries.
+//
+// An unparseable half yields null rather than an approximate date. A wrong
+// publication date is worse than a missing one -- it is the field that decides
+// which adaptation came first.
+export function parsePublished(
+  value: string | null,
+  parseDate: (s: string, f: string, ref: Date) => Date,
+  isValidDate: (d: Date) => boolean,
+): { from: Date | null; to: Date | null } {
+  if (!value || value.trim().toLowerCase() === 'not available') {
+    return { from: null, to: null }
+  }
+
+  // MAL pads the day: "Dec  22, 1995 to May  10, 2005", two spaces after the
+  // month. date-fns matches the literal separator in the format string, so
+  // 'LLL d, yyyy' fails on it and every publication date comes back null --
+  // which is the field that decides which adaptation came first.
+  const [rawFrom, rawTo] = value.replace(/\s+/g, ' ').split(' to ')
+
+  const one = (part: string | undefined): Date | null => {
+    const text: string = (part || '').trim()
+    if (!text || text === '?') {
+      return null
+    }
+
+    for (const format of ['LLL d, yyyy', 'LLL yyyy', 'yyyy']) {
+      const parsed: Date = parseDate(text, format, new Date())
+      if (isValidDate(parsed)) {
+        return parsed
+      }
+    }
+
+    return null
+  }
+
+  return { from: one(rawFrom), to: one(rawTo) }
+}

--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -15,6 +15,18 @@ import { RECORD_TYPE } from './repository/interface'
 import { AnimeStaffEntity } from '../anime/repository/animeStaff.entity'
 import { AnimeCharacterEntity } from '../anime/repository/animeCharacters.entity'
 import { SeasonYear, parseSeasonYear, Season } from '../common/season.types'
+import { WorkService } from '../work/work.service'
+import { cleanScrapedList } from '../common/scrapedList'
+import {
+  readSidebar,
+  rowText,
+  rowList,
+  malNumber,
+  toWorkType,
+  malIdFromUrl,
+  parsePublished,
+  SidebarRow,
+} from './mangaPage'
 
 @Injectable()
 export class MyanimelistService {
@@ -45,6 +57,7 @@ export class MyanimelistService {
     private readonly myanimelistlinkRepo: MyanimelistlinkRepository,
     private readonly animeService: AnimeService,
     private readonly scrapeRecordService: ScrapeRecordService,
+    private readonly workService: WorkService,
   ) {
   }
 
@@ -624,6 +637,130 @@ export class MyanimelistService {
     this.scrapeRecordService.recordSuccessfulScrape(data)
   }
 
+
+  /**
+   * Scrapes a MAL manga page into a `work` row.
+   *
+   * The manga family -- manga, light novels, novels, manhwa, manhua, one-shots
+   * -- all live at /manga/<id> and differ only by the Type field, so this one
+   * path covers every source an anime can be adapted from that MAL knows about.
+   * That is roughly 10,300 anime: everything except originals and the game and
+   * visual novel sources, which need VNDB or IGDB.
+   *
+   * Same cluster, session and captcha handling as scrapeAnimePage. What differs
+   * is the sidebar, which is read as structure rather than text -- see
+   * mangaPage.ts for why splitting it on commas is not an option.
+   */
+  public async scrapeMangaPage({ page, data }: any): Promise<void> {
+    const url: string = data.url || data
+    this.logger.debug(`Scraping manga page ${url}`)
+
+    await page.setRequestInterception(true)
+    page.on('request', (request: any): void => {
+      if (request.url().endsWith('.js')) {
+        request.abort()
+      } else {
+        request.continue()
+      }
+    })
+    await page.setDefaultNavigationTimeout(5 * 60 * 1000)
+
+    const pageLoaded: boolean = await this.gotoWithTimeout(page, url)
+    if (!pageLoaded) {
+      this.logger.warn(`Continuing with partial page load for manga: ${url}`)
+    }
+    await this.handleCaptchas(page)
+
+    const rows: SidebarRow[] = await page.evaluate(readSidebar)
+
+    const titleHeader: string = await ClusterManager.pageFindOne(
+      page,
+      '.title-name.h1_bold_none',
+      'textContent',
+    )
+    const titleEn: string = rowText(rows, 'english') || titleHeader
+    const titleJp: string = rowText(rows, 'japanese')
+
+    // The same guard scrapeAnimePage uses: a page with neither title did not
+    // load properly, and retrying is better than writing an empty row.
+    if (!titleEn && !titleJp) {
+      throw new Error('No english or japanese title, should retry')
+    }
+
+    let imageUrl: string = await ClusterManager.pageFindOne(
+      page,
+      '.leftside img',
+      'src',
+    )
+    if (!imageUrl) {
+      imageUrl = await ClusterManager.pageFindOne(
+        page,
+        'meta[property="og:image"]',
+        'content',
+      )
+    }
+
+    const synopsis: string = await ClusterManager.pageFindOne(
+      page,
+      'span[itemprop="description"]',
+      'textContent',
+    )
+
+    const rankContent: string = await ClusterManager.pageFindOne(
+      page,
+      '.numbers.ranked strong',
+      'textContent',
+    )
+    const scoreLabel: string = await ClusterManager.pageFindOne(
+      page,
+      '.score .score-label',
+      'textContent',
+    )
+
+    const published = parsePublished(rowText(rows, 'published'), ParseDate, isValid)
+
+    const sanitizedURL: string = url.split('?')[0]
+
+    const work = await this.workService.upsertWork({
+      malId: malIdFromUrl(sanitizedURL),
+      type: toWorkType(rowText(rows, 'type')),
+      titleEn,
+      titleJp,
+      // Synonyms are the one list MAL leaves as plain comma-separated text.
+      titleSynonyms: cleanScrapedList(
+        (rowText(rows, 'synonyms') || '').split(','),
+      ),
+      synopsis,
+      imageUrl,
+      status: rowText(rows, 'status'),
+      volumes: malNumber(rowText(rows, 'volumes')),
+      chapters: malNumber(rowText(rows, 'chapters')),
+      publishedFrom: published.from,
+      publishedTo: published.to,
+      // Cleaned like the lists are: MAL writes an absent serialization as the
+      // literal "None", and demographic is simply missing on light novels.
+      demographic: cleanScrapedList(rowList(rows, 'demographic')).join(', ') || null,
+      serialization: cleanScrapedList(rowList(rows, 'serialization')).join(', ') || null,
+      authors: cleanScrapedList(rowList(rows, 'authors')),
+      score: malNumber(scoreLabel),
+      ranking: malNumber(rankContent),
+      members: malNumber(rowText(rows, 'members')),
+      favorites: malNumber(rowText(rows, 'favorites')),
+    })
+
+    // Record the URL against the work, so an anime page naming this manga can
+    // resolve it later. This is the same table the anime path uses; record_id
+    // is what lets it point at something that is not an anime.
+    await this.myanimelistlinkRepo.upsert({
+      name: titleEn || titleJp,
+      link: sanitizedURL,
+      type: RECORD_TYPE.Manga,
+      recordId: work.id,
+    })
+
+    this.scrapeRecordService.recordSuccessfulScrape(sanitizedURL)
+    this.logger.info(`Scraped manga ${titleEn || titleJp} (${work.id})`)
+  }
 
   public async scrapeCharactersAndStaff({ page, data }: any) {
     // When called from queue, data is the entire queued object

--- a/src/modules/scraper/scraper.service.ts
+++ b/src/modules/scraper/scraper.service.ts
@@ -165,6 +165,73 @@ export class ScraperService {
     return 'ok'
   }
 
+  /**
+   * Scrapes MAL manga pages into `work` rows.
+   *
+   * URLs are supplied rather than generated. The natural source of them is the
+   * anime pages themselves -- step 6 records the source link each anime names --
+   * so a discovery crawl of MAL's manga index is not needed to get value out of
+   * this: the manga worth having are exactly the ones something adapts.
+   */
+  async scrapeMyAnimeListManga(
+    param: string[],
+    limit: number,
+    headless: boolean,
+    urls?: string[],
+  ) {
+    await this.puppeteerService.setup(limit, headless)
+
+    await this.puppeteerService
+      .getManager()
+      .task(
+        async ({ page, data }: any) =>
+          this.myanimelistService.scrapeMangaPage({ page, data }),
+      )
+
+    this.puppeteerService
+      .getManager()
+      .getCluster()
+      .on('taskerror', (err: any, data: any, willRetry: any) => {
+        if (willRetry) {
+          this.logger.warn(
+            `Encountered an error while crawling ${data}. ${err.message}\nThis job will be retried`,
+          )
+        } else {
+          this.logger.error(`Failed to crawl ${data}: ${err.message}`)
+        }
+      })
+
+    let processUrls: string[] = urls && urls.length > 0 ? urls : param
+    if (!processUrls || processUrls.length === 0) {
+      this.logger.error(
+        'No manga URLs given. Pass them as arguments or with --file.',
+      )
+
+      return 'no urls'
+    }
+
+    // Same resume behaviour as the anime crawl: a run that dies partway through
+    // does not start from the beginning.
+    const alreadyScraped: Set<string> = this.scrapeRecordService.getScrapedUrls()
+    const beforeCount: number = processUrls.length
+    processUrls = processUrls.filter((url: string) => !alreadyScraped.has(url))
+    if (beforeCount !== processUrls.length) {
+      this.logger.info(
+        `Resuming: skipping ${beforeCount - processUrls.length} already-scraped URLs, ${processUrls.length} remaining`,
+      )
+    }
+
+    await Promise.all(
+      processUrls.map((url: string) =>
+        this.puppeteerService.getManager().queue({ url, type: 'manga' }),
+      ),
+    )
+    await this.puppeteerService.getManager().idle()
+    await this.puppeteerService.getManager().close()
+
+    return 'ok'
+  }
+
   async scrapeNewlyAdded(
     param: string[],
     limit: number,


### PR DESCRIPTION
Step 5 of `docs/manga-and-works.md`. Reuses the anime path's Puppeteer cluster, session handling, captcha handling and resume behaviour; the manga-specific part is reading the sidebar.

## Reading the sidebar as structure, not text

Each sidebar row's value is a set of `<a>` elements. Taking their text instead of splitting the row is the whole ballgame — MAL writes authors surname-first:

```
text   "Hasekura, Isuna (Story), Ayakura, Juu (Art)"
links  ["Hasekura, Isuna", "Ayakura, Juu"]
```

Splitting that row on commas gives four fragments and cuts every author in half. It is the same mistake that put `" Inc."` in `anime.studios` as a studio credited on 19 anime.

## Verified against live MAL pages, not assumed

I loaded two real pages (a Manga and a Light Novel) and ran the extraction against them. **Three things would have shipped broken:**

| Found | Consequence if unfixed |
|---|---|
| `published` reads `"Dec  22, 1995 to May  10, 2005"` — **two spaces** after the month | date-fns matches separators literally, so `'LLL d, yyyy'` fails and **every publication date would be null** — the field that decides which adaptation came first |
| Manga synopses use `span[itemprop="description"]`, not the anime page's `p[itemprop]` | synopsis always null (`p` variant returns nothing; `span` returns 813 chars) |
| `serialization` is the literal `"None"` when absent; `demographic` is absent entirely on light novels | `"None"` stored as a real serialization |

Also confirmed the sidebar's own score row is unusable — `"8.821 (scored by 1738617,386 users)"` — so score comes from `.score .score-label`, which reads `8.82`.

Date parsing re-verified against the actual strings after the fix:

```
"Dec  22, 1995 to May  10, 2005"  ->  1995-12-22 / 2005-05-10
"Feb  10, 2006 to ?"              ->  2006-02-10 / null
"2005"                            ->  2005-01-01 / null
"Oct 2019"                        ->  2019-10-01 / null
```

Type mapping confirmed too: `"Light Novel"` → `LIGHT_NOVEL`, `Volumes/Chapters: "Unknown"` → null.

## What it writes

A `work` row keyed on the MAL id, plus a `myanimelist_link` of type `Manga` pointing at it via `record_id` — which is what #13 and #14 exist for. An anime page naming this manga can then resolve it.

## Usage

```
node main.js scrape manga --msite myanimelist --mheadless --mlimit 1 <url>...
node main.js scrape manga --msite myanimelist --mheadless --file manga-urls.json
```

URLs are supplied rather than discovered: MAL's manga database is far larger than the part worth having, and the part worth having is whatever something adapts. Step 6 is what feeds this.

## Verified

`tsc --noEmit` and `yarn build` clean. No migration needed — the schema landed in #15.
