### PR TITLE
feat: record which work an anime adapts

### DIFF
--- a/docs/manga-and-works.md
+++ b/docs/manga-and-works.md
@@ -170,19 +170,22 @@ every re-adaptation case, which nothing else reaches.
 
 ## Steps
 
-Ordered. Nothing after step 1 is started.
+Ordered. Steps 1-6 are done and in main.
 
-1. **`myanimelist_link.record_id`** — written, committed on branch
-   `feat/work-table`, not yet raised as a pull request:
-   `migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts`.
-   Adds `record_id`, backfills from `anime_id`, indexes `(link)` uniquely and
+1. **`myanimelist_link.record_id`** — done (#13).
+   `migrations/1787184000000-GeneralizeMyanimelistLinkRecordId.ts` adds
+   `record_id`, backfills from `anime_id`, indexes `(link)` uniquely and
    `(type, record_id)`. Leaves `anime_id` in place so the migration and the
-   code change can deploy independently; drop it in a follow-up.
+   code change can deploy independently; drop it in a follow-up. The unique
+   index needed a dedupe first: 486 links had duplicated because the upsert
+   matched on a title MAL rewrites freely.
 
-2. **Entity and repository** — `MyanimelistLinks.recordId`, and resolution
-   helpers that take a `RECORD_TYPE`.
+2. **Entity and repository** — done (#14). `MyanimelistLinks.recordId`, and
+   `resolveByLink` answering "given this MAL URL, what is our id and what kind
+   of record is it". `upsert` mirrors `animeId` into `recordId` so the column
+   keeps filling without any caller changing.
 
-3. **`work` table** in Postgres:
+3. **`work` table** in Postgres — done (#15):
 
    ```
    work(id, mal_id, type, title_en, title_jp, title_synonyms, synopsis,
@@ -199,16 +202,33 @@ Ordered. Nothing after step 1 is started.
    with 19 anime -- so normalising `authors` the way genres became `tags`
    is worth doing at creation rather than later.
 
-4. **`anime.source_work_id`** — nullable, indexed. One column covers the
-   overwhelming majority; an anime adapting several works is rare enough to
-   defer a link table.
+4. **`anime.source_work_id`** — done (#15). Nullable, indexed, no foreign key:
+   scrape order is not dependency order, and step 6 depends on being able to
+   record a relation before the other side exists.
 
-5. **Scraper: MAL manga pages.** Same Puppeteer cluster, session and captcha
-   handling as the anime path. Parse the sidebar labels listed above.
+5. **Scraper: MAL manga pages** — done (#16). `scrape manga`. Three things had
+   to be read off live pages rather than assumed: MAL pads the day
+   (`"Dec  22, 1995"`, two spaces) so `LLL d, yyyy` fails on it; manga synopses
+   are in `span[itemprop="description"]`, not the anime page's `p[itemprop]`;
+   and `Serialization` is the literal string `"None"` when absent. The sidebar
+   is read as anchors rather than text, because MAL writes authors surname
+   first -- `"Hasekura, Isuna (Story), Ayakura, Juu (Art)"` -- and splitting
+   that on commas halves every author, which is the bug already sitting in
+   `anime.studios`.
 
-6. **Scraper: capture the source link on anime pages.** Store the MAL URL
-   unresolved, resolve later via `myanimelist_link` — the same pattern that
-   makes relations recoverable.
+6. **Scraper: capture the source link on anime pages** — done. The
+   non-obvious part: MAL states the source twice and the two disagree. The
+   sidebar gives a kind, Related Entries gives entries, and a light novel
+   series lists **both** an `Adaptation (Manga)` and an
+   `Adaptation (Light Novel)`. Spice & Wolf's anime adapts the novel; the manga
+   is a sibling adaptation. Taking the first Adaptation records a relation that
+   is wrong, and wrong is worse than absent here. The sidebar's `Source` picks
+   between them, and an ambiguous page stores nothing.
+
+   Unresolved links are kept in `myanimelist_link` so `scrape manga` can be
+   pointed at them; the anime resolves on a later pass. There is no backfill
+   from the manga side -- nothing records which anime asked -- so resolution
+   happens when the anime is next scraped.
 
 7. **Read path** — ordinary. `work` is a table in the read store beside
    `anime`, so `anime.source_work_id` is a column and both directions are a

--- a/src/modules/anime/anime.service.ts
+++ b/src/modules/anime/anime.service.ts
@@ -79,6 +79,17 @@ export class AnimeService {
     return upsertedAnime
   }
 
+  /**
+   * Points an anime at the work it adapts.
+   *
+   * A targeted update rather than an upsert: the anime row has just been
+   * written from the page, and re-upserting the whole record to set one column
+   * would emit a second CDC event for every field.
+   */
+  async setSourceWork(animeId: string, workId: string): Promise<void> {
+    await this.animeRepository.update({ id: animeId }, { source_work_id: workId })
+  }
+
   upsertAnimeEpisode(animeID: string, episode: AnimeEpisodesEntity) {
     return this.animeEpisodesRepository.upsert({
       ...episode,

--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -17,6 +17,7 @@ import { AnimeCharacterEntity } from '../anime/repository/animeCharacters.entity
 import { SeasonYear, parseSeasonYear, Season } from '../common/season.types'
 import { WorkService } from '../work/work.service'
 import { cleanScrapedList } from '../common/scrapedList'
+import { readAdaptations, pickSourceAdaptation, AdaptationEntry } from './relatedEntries'
 import {
   readSidebar,
   rowText,
@@ -577,6 +578,9 @@ export class MyanimelistService {
       parsedData.title_en || parsedData.title_jp || 'Unknown',
     )
 
+    // Record which work this anime adapts, if the page says.
+    await this.captureSourceWork(page, upsertedAnime.id, res['source'])
+
     // Add season tracking if seasonYear is provided
     if (seasonYear && upsertedAnime.id) {
       try {
@@ -637,6 +641,61 @@ export class MyanimelistService {
     this.scrapeRecordService.recordSuccessfulScrape(data)
   }
 
+
+  /**
+   * Links an anime to the work it adapts.
+   *
+   * MAL states the source twice. The sidebar gives the kind -- "Manga", "Light
+   * novel" -- and Related Entries gives the actual entries, and for a light
+   * novel series both an Adaptation (Manga) and an Adaptation (Light Novel) are
+   * routinely listed. Spice & Wolf is the clear case: the anime adapts the
+   * novel, and the manga is a sibling adaptation of it. The sidebar's Source is
+   * what tells the two apart, so it is passed in rather than guessed at.
+   *
+   * When the work has not been scraped yet the URL is stored unresolved, which
+   * is the point of myanimelist_link carrying a record_id: the link survives,
+   * `scrape manga` can be pointed at it, and a later pass over the anime
+   * resolves it. Nothing is lost by not knowing yet.
+   */
+  private async captureSourceWork(
+    page: any,
+    animeId: string,
+    source: string | null,
+  ): Promise<void> {
+    if (!animeId) {
+      return
+    }
+
+    try {
+      const entries: AdaptationEntry[] = await page.evaluate(readAdaptations)
+      const picked: AdaptationEntry = pickSourceAdaptation(entries, source)
+      if (!picked) {
+        return
+      }
+
+      const link: string = picked.href.split('?')[0]
+      const resolved = await this.myanimelistlinkRepo.resolveByLink(link)
+
+      if (resolved && resolved.recordId) {
+        await this.animeService.setSourceWork(animeId, resolved.recordId)
+        this.logger.debug(`Linked anime ${animeId} to work ${resolved.recordId}`)
+
+        return
+      }
+
+      // Not scraped yet. Keep the URL so it can be, and so this resolves on a
+      // later pass instead of being rediscovered from scratch.
+      await this.myanimelistlinkRepo.upsert({
+        name: picked.title,
+        link,
+        type: RECORD_TYPE.Manga,
+      })
+      this.logger.debug(`Recorded unresolved source work ${link} for anime ${animeId}`)
+    } catch (e) {
+      // A missing source relation is not a reason to fail the anime scrape.
+      this.logger.warn(`Could not capture source work for anime ${animeId}: ${e.message}`)
+    }
+  }
 
   /**
    * Scrapes a MAL manga page into a `work` row.

--- a/src/modules/myanimelist/relatedEntries.ts
+++ b/src/modules/myanimelist/relatedEntries.ts
@@ -1,0 +1,126 @@
+// The source relation on a MAL anime page.
+//
+// MAL states the source twice and the two disagree in a way that matters. The
+// sidebar says what kind of thing was adapted -- "Manga", "Light novel" -- and
+// the Related Entries section lists the actual entries, which for a light novel
+// series routinely includes both:
+//
+//   source: "Light novel"
+//     Adaptation (Manga)        -> /manga/3299
+//     Adaptation (Light Novel)  -> /manga/9115
+//
+// That is Spice & Wolf. The anime adapts the light novel; the manga is itself
+// an adaptation of the same novel. Taking the first Adaptation entry picks the
+// manga and records a relation that is simply wrong -- and wrong here is worse
+// than absent, because relating adaptations to each other is the entire point.
+//
+// So the sidebar's Source is used to choose between them.
+
+export interface AdaptationEntry {
+  readonly relation: string
+  readonly kind: string
+  readonly href: string
+  readonly title: string
+}
+
+// Runs in the page.
+export function readAdaptations(): AdaptationEntry[] {
+  const norm = (s: string | null | undefined): string =>
+    (s || '').replace(/\s+/g, ' ').trim()
+
+  const found: AdaptationEntry[] = []
+
+  const push = (relation: string, href: string | null, title: string): void => {
+    if (!href || !/\/manga\/\d+/.test(href)) {
+      return
+    }
+    // "Adaptation (Light Novel)" -> kind "Light Novel"
+    const match: RegExpMatchArray | null = relation.match(/\(([^)]+)\)/)
+    found.push({
+      relation,
+      kind: match ? match[1] : '',
+      href,
+      title,
+    })
+  }
+
+  // The tile layout, which is what MAL serves today.
+  document.querySelectorAll('.related-entries .entry').forEach((entry: Element) => {
+    const anchor: HTMLAnchorElement | null = entry.querySelector('.title a')
+    // Some .entry nodes carry no link at all; skipping them is not an error.
+    if (!anchor) {
+      return
+    }
+    push(
+      norm(entry.querySelector('.relation')?.textContent),
+      anchor.getAttribute('href'),
+      norm(anchor.textContent),
+    )
+  })
+
+  // The table layout, which still appears inside .related-entries for some
+  // relation kinds and standalone on older entries.
+  document
+    .querySelectorAll('.related-entries table tr, table.anime_detail_related_anime tr')
+    .forEach((row: Element) => {
+      const label: string = norm(
+        row.querySelector('td.ar, td:first-child')?.textContent,
+      ).replace(/:$/, '')
+      row.querySelectorAll('td a').forEach((anchor: Element) => {
+        push(label, anchor.getAttribute('href'), norm(anchor.textContent))
+      })
+    })
+
+  return found
+}
+
+// MAL's Source wording against the parenthetical on a related entry. They are
+// not spelled identically -- "Light novel" against "(Light Novel)" -- so both
+// sides are folded before comparing.
+function fold(value: string): string {
+  return value.toLowerCase().replace(/[^a-z]/g, '')
+}
+
+/**
+ * Picks the entry the anime is actually adapted from.
+ *
+ * Returns null rather than guessing when the page is ambiguous: several
+ * adaptations and no Source to choose between them. A null source_work_id is
+ * the honest answer and the next scrape can revisit it; a wrong one silently
+ * relates two unrelated series.
+ */
+export function pickSourceAdaptation(
+  entries: readonly AdaptationEntry[],
+  source: string | null,
+): AdaptationEntry | null {
+  const adaptations: AdaptationEntry[] = entries.filter((entry: AdaptationEntry) =>
+    /adaptation/i.test(entry.relation),
+  )
+
+  // MAL lists the same entry in both layouts, so the same href arrives twice.
+  const seen: Set<string> = new Set()
+  const unique: AdaptationEntry[] = adaptations.filter((entry: AdaptationEntry) => {
+    if (seen.has(entry.href)) {
+      return false
+    }
+    seen.add(entry.href)
+
+    return true
+  })
+
+  if (unique.length === 0) {
+    return null
+  }
+
+  if (source) {
+    const matched: AdaptationEntry = unique.find(
+      (entry: AdaptationEntry) => entry.kind && fold(entry.kind) === fold(source),
+    )
+    if (matched) {
+      return matched
+    }
+  }
+
+  // One candidate and nothing to contradict it.
+  return unique.length === 1 ? unique[0] : null
+}


### PR DESCRIPTION
Step 6 of `docs/manga-and-works.md` — and the step that closes the loop: anime pages are what tell us which manga are worth scraping, so `scrape manga` stops needing a hand-written URL list.

## The trap, found on a live page

MAL states the source **twice**, and the two disagree:

```
source: "Light novel"
  Adaptation (Manga)        -> /manga/3299
  Adaptation (Light Novel)  -> /manga/9115
```

That's Spice & Wolf's anime. It adapts the **light novel**; the manga is a *sibling* adaptation of the same novel. Taking the first `Adaptation` entry picks the manga and records a relation that is flatly wrong — and wrong is worse than absent here, because relating re-adaptations to each other is the entire reason `source_work_id` exists. Nothing would ever flag it.

So the sidebar's `Source` is used to choose between candidates, and **an ambiguous page stores nothing**. A null is recoverable on the next scrape; a wrong link is not.

## Verified against real pages and real cases

Structures were read off live MAL pages (Vinland Saga, Fruits Basket 2001, Spice & Wolf), which is where the duplicate-listing and empty-`.entry` cases came from. The picking logic then ran against that captured data:

```
PASS  Spice & Wolf  (LN source, LN + Manga both listed)   -> /manga/9115
PASS  Vinland Saga (same entry listed twice)              -> deduped
PASS  Fruits Basket 2001                                  -> /manga/102
PASS  Original anime, no adaptation                       -> null
PASS  Ambiguous: 2 adaptations, source matches neither     -> null
PASS  Single adaptation, Source field absent               -> accepted
```

Fruits Basket is the payoff case: the 2001 and 2019 series both resolve to `/manga/102`, which is exactly the relation nothing else can find — they share no TheTVDB id and no cast.

Both MAL layouts are handled (the modern `.related-entries` tiles and the table that still appears for some relation kinds), and `.entry` nodes with no link are skipped rather than throwing.

## Unresolved links

When the work has not been scraped yet, the URL is stored in `myanimelist_link` unresolved — which is what `record_id` was added for. The link survives, `scrape manga` can be pointed at it, and the anime resolves on a later pass.

**Known gap, stated plainly:** there is no backfill from the manga side, because nothing records *which* anime asked for a given URL. Resolution happens when the anime is next scraped. Given the scraper re-scrapes on a schedule this self-heals, but if you want it immediate that's a small follow-up (either a `source_work_url` column or a resolve-pass command).

## Verified

`tsc --noEmit` and `yarn build` clean. No migration — the column landed in #15. Failure to read a source relation is caught and logged, never fails the anime scrape.
