### PR TITLE
fix: store work.score as double precision so CDC can carry it

### DIFF
--- a/migrations/1787360400000-WorkScoreToDoublePrecision.ts
+++ b/migrations/1787360400000-WorkScoreToDoublePrecision.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Changes work.score from numeric(4,2) to double precision.
+ *
+ * Not a modelling preference -- numeric is the better type for a score, and if
+ * this table were read only by SQL it would stay. The problem is what Debezium
+ * does with it.
+ *
+ * Debezium's decimal.handling.mode defaults to `precise`, which encodes numeric
+ * columns as base64 bytes plus a scale from the schema rather than as a JSON
+ * number. A consumer unmarshalling into *float64 does not get 8.82; it gets a
+ * decode error, or worse, silence. work.score is the only numeric column in
+ * this entire schema, so nothing has hit this before and nothing else changes
+ * if it moves.
+ *
+ * The alternative was setting decimal.handling.mode=double on the connector,
+ * which is a change to every table it captures and needs the connector
+ * restarted, to fix one column that has no rows yet. This is the smaller blast
+ * radius by a wide margin.
+ *
+ * float8 holds a two-decimal score exactly well enough: MAL publishes one
+ * decimal place of real precision (8.82 is already a rounded mean of millions
+ * of votes) and nothing arithmetic is done with it downstream.
+ */
+export class WorkScoreToDoublePrecision1787360400000 implements MigrationInterface {
+    name = 'WorkScoreToDoublePrecision1787360400000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // No USING clause needed: numeric to double precision is an assignment
+        // cast, and the table is empty regardless.
+        await queryRunner.query(`ALTER TABLE "work" ALTER COLUMN "score" TYPE double precision`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "work" ALTER COLUMN "score" TYPE numeric(4,2)`);
+    }
+}

--- a/src/modules/work/repository/work.entity.ts
+++ b/src/modules/work/repository/work.entity.ts
@@ -88,7 +88,10 @@ export class Work {
   @Column('text', { name: 'authors', nullable: true, transformer: jsonArray })
   authors: string[]
 
-  @Column({ name: 'score', nullable: true, type: 'numeric', precision: 4, scale: 2 })
+  // double precision, not numeric. Debezium encodes numeric columns as base64
+  // bytes under its default decimal.handling.mode, which a float consumer
+  // cannot read -- see migration 1787360400000.
+  @Column({ name: 'score', nullable: true, type: 'double precision' })
   score: number
 
   @Column({ name: 'ranking', nullable: true, type: 'int' })


### PR DESCRIPTION
Found while building the `work` CDC consumer, and worth landing before it rather than debugging after.

## The problem

Debezium's `decimal.handling.mode` defaults to **`precise`**, which encodes `numeric` columns as **base64 bytes plus a scale**, not as a JSON number. A consumer unmarshalling that into `*float64` doesn't get `8.82` — it gets a decode error, or silently nothing.

I checked the deployed connector config: no `decimal.handling.mode` is set, so it is on the default.

## Why nothing has hit this before

`work.score` is the **only** numeric column in the entire scraper schema:

```
select table_name||'.'||column_name||' :: '||data_type
  from information_schema.columns
 where table_schema='public'
   and data_type in ('numeric','decimal','real','double precision');

  work.score :: numeric
```

`anime.rating` is varchar and `ranking` is an int, so no existing consumer has ever had to decode one.

## Why not fix it on the connector

Setting `decimal.handling.mode=double` would work, but it changes the encoding for **every table Debezium captures** and needs the connector restarted — to fix one column that currently has zero rows. Changing the column is the smaller blast radius by a wide margin.

`float8` is precise enough for what this holds: MAL publishes one meaningful decimal place (8.82 is already a rounded mean of millions of votes) and nothing downstream does arithmetic with it.

## Verified

`tsc --noEmit` and `yarn build` clean. The table is empty, so the `ALTER` needs no `USING` clause and rewrites nothing.

## Needs a migration run

`npm run typeorm -- migration:run` after merge — along with #18's slug migration if you haven't run that yet.

The read store's copy (anime-api migration 000063) declares `numeric(4,2)` too and will need the same change; that comes with the consumer PR, since nothing writes to it until then.