### PR TITLE
fix: declare the --file option on the manga command

### DIFF
--- a/src/modules/commander/manga.command.ts
+++ b/src/modules/commander/manga.command.ts
@@ -58,6 +58,19 @@ export class MangaCommand extends CommandRunner {
     )
   }
 
+  // Declared, not just read. nest-commander only populates options that have
+  // an @Option; the field existing on the options interface is not enough, and
+  // TypeScript cannot see the difference. Without this, --file parsed on the
+  // parent command, never reached here, and every run ended with "No manga URLs
+  // given" while appearing to have been passed a file.
+  @Option({
+    flags: '--file [file]',
+    description: 'JSON file holding an array of MyAnimeList manga URLs',
+  })
+  getFile(val: string): string {
+    return val
+  }
+
   @Option({
     flags: '-ms, --msite [site]',
     description: 'What site to scrape (only myanimelist)',


### PR DESCRIPTION
`scrape manga --file` was silently ignored — every run ended with:

```
INFO  Pased val: /urls/manga-urls.json
ERROR No manga URLs given. Pass them as arguments or with --file.
```

which is a confusing pair of lines to land on.

## Cause

`MangaCommandOptions` had a `file` field and `run()` read `options.file`, but I never added the `@Option` decorator for it — only `--msite`, `--mlimit` and `--mheadless`. **nest-commander only populates options that carry a decorator**; having the field on the interface is not enough, and TypeScript cannot tell a declared option from a merely-typed one. It compiled cleanly and failed only at runtime.

What made it *look* like the flag worked: the parent `scrape` command does declare `--file`, so commander parsed it there and logged the path. The subcommand never received it.

## Impact

None to data. Positional URLs were always handled (`run()` falls back to `passedParam`), which is how the backfill proceeded meanwhile — 8 works scraped and confirmed through to the read store.

## Verified

`tsc --noEmit` and `yarn build` clean. The decorator matches the three existing ones exactly.