### PR TITLE
feat: keep the author's MyAnimeList link when scraping a manga

### DIFF
--- a/src/modules/myanimelist/mangaPage.ts
+++ b/src/modules/myanimelist/mangaPage.ts
@@ -13,6 +13,13 @@ export interface SidebarRow {
   readonly label: string
   readonly text: string
   readonly links: string[]
+  // The hrefs behind those same anchors, in the same order.
+  //
+  // MyAnimeList links every author to /people/<id>, which is the only durable
+  // identifier a person has -- names are romanised inconsistently and get
+  // rewritten. Keeping only the text throws that away, and recovering it later
+  // means re-scraping every manga page rather than reading a column.
+  readonly hrefs: string[]
 }
 
 // Runs in the page. Returns one entry per sidebar row.
@@ -32,8 +39,16 @@ export function readSidebar(): SidebarRow[] {
       label,
       text: (row.textContent || '').replace(span?.textContent || '', '').trim(),
       links: anchors.map((a: Element) => (a.textContent || '').trim()),
+      hrefs: anchors.map((a: Element) => (a as HTMLAnchorElement).href || ''),
     }
   })
+}
+
+/** The anchor hrefs on a row, paired with the text rowList returns. */
+export function rowHrefs(rows: SidebarRow[], label: string): string[] {
+  const row: SidebarRow = rows.find((r: SidebarRow) => r.label === label)
+
+  return row ? row.hrefs : []
 }
 
 export function rowText(rows: SidebarRow[], label: string): string | null {

--- a/src/modules/myanimelist/myanimelist.service.ts
+++ b/src/modules/myanimelist/myanimelist.service.ts
@@ -20,6 +20,7 @@ import { cleanScrapedList } from '../common/scrapedList'
 import { readAdaptations, pickSourceAdaptation, AdaptationEntry } from './relatedEntries'
 import {
   readSidebar,
+  rowHrefs,
   rowText,
   rowList,
   malNumber,
@@ -643,6 +644,46 @@ export class MyanimelistService {
 
 
   /**
+   * Records each author's MyAnimeList page against their name.
+   *
+   * Stored unresolved, the same way a source work is: the URL is kept now and
+   * turned into one of our ids whenever that person is scraped. MyAnimeList
+   * serves authors from /people/<id>, the same namespace as the voice actors
+   * this scraper already collects, so an author is not a new kind of record --
+   * it is a person we have a link to and have not fetched yet.
+   *
+   * Worth keeping even before anything reads it. A name is not an identity:
+   * MyAnimeList romanises inconsistently and rewrites entries, which is exactly
+   * how myanimelist_link accumulated 486 duplicates keyed on titles. The id in
+   * the URL is stable, and recovering it later would mean re-scraping every
+   * manga page rather than reading a column.
+   */
+  private async recordAuthorLinks(rows: SidebarRow[], workId: string): Promise<void> {
+    const names: string[] = rowList(rows, 'authors')
+    const hrefs: string[] = rowHrefs(rows, 'authors')
+
+    for (let i = 0; i < hrefs.length; i++) {
+      const href: string = (hrefs[i] || '').split('?')[0]
+      // Only people links. The row can carry others, and a link we cannot key
+      // on is worse than no link at all.
+      if (!/\/people\/\d+/.test(href)) {
+        continue
+      }
+
+      try {
+        await this.myanimelistlinkRepo.upsert({
+          name: names[i] || href,
+          link: href,
+          type: RECORD_TYPE.Staff,
+        })
+      } catch (e) {
+        // One unrecordable author is not a reason to fail a scraped work.
+        this.logger.warn(`Could not record author link ${href} for work ${workId}: ${e.message}`)
+      }
+    }
+  }
+
+  /**
    * Links an anime to the work it adapts.
    *
    * MAL states the source twice. The sidebar gives the kind -- "Manga", "Light
@@ -816,6 +857,8 @@ export class MyanimelistService {
       type: RECORD_TYPE.Manga,
       recordId: work.id,
     })
+
+    await this.recordAuthorLinks(rows, work.id)
 
     this.scrapeRecordService.recordSuccessfulScrape(sanitizedURL)
     this.logger.info(`Scraped manga ${titleEn || titleJp} (${work.id})`)


### PR DESCRIPTION
The sidebar parser read the **text** of each author anchor and threw the href away. That href is `/people/<id>` — the only stable identifier a person has.

## Why now, not later

**The backfill is running.** Every manga scraped without this needs re-scraping to recover the links. It costs one row per author to keep them.

A name is not an identity: MyAnimeList romanises inconsistently and rewrites entries, which is precisely how `myanimelist_link` accumulated 486 duplicates keyed on titles. The id in the URL does not move.

## How

Stored **unresolved** against `RECORD_TYPE.Staff`, the same pattern step 6 uses for source works: keep the URL now, turn it into one of our ids whenever that person is scraped.

An author is not a new kind of record — MyAnimeList serves authors from `/people/<id>`, the same namespace as the voice actors this scraper already collects via `scrapeVoiceActorDetails`.

## Nothing reads these yet

Deliberately. They make an author page a read-side problem later rather than another full crawl. Only `/people/` links are recorded; anything else on the row is skipped, since a link we cannot key on is worse than no link.

A failure to record one author logs and continues rather than failing the scraped work.

## Verified

`tsc --noEmit` and `yarn build` clean.