### PR TITLE
fix: enable positional options on the root program too

### DIFF
--- a/src/server/server.app.ts
+++ b/src/server/server.app.ts
@@ -1,4 +1,6 @@
+import { Command } from 'commander'
 import { CommandFactory } from 'nest-commander'
+import { Commander } from 'nest-commander/src/constants'
 import { ConfigService } from './../modules/config/config.service'
 import { ServerConfig } from './server.config'
 import { BootstrapModule } from './bootstrap.module'
@@ -18,25 +20,36 @@ export async function start(): Promise<void> {
   app.enableCors({ origin: true, credentials: true });
   app.useGlobalPipes(new ValidationPipe());*/
 
-  await CommandFactory.runWithoutClosing(
+  // Positional options: an option belongs to the command it follows.
+  //
+  // Without them commander matches a parent's option anywhere on the line, so
+  // `scrape manga --file urls.json` hands --file to `scrape` and the manga
+  // subcommand never sees it. That is why the subcommands here grew prefixed
+  // options -- csite and climit on `new`, msite and mlimit on `manga` -- and
+  // why --file silently did nothing even once it was declared: declaring an
+  // option the parent already owns is not enough to win it.
+  const app = await CommandFactory.createWithoutRunning(
     // @ts-ignore
     BootstrapModule.forRoot(serverConfig),
     {
       logger: ['log', 'debug', 'warn', 'error'],
-      // Without this, commander matches a parent's options anywhere on the line,
-      // so `scrape manga --file urls.json` hands --file to `scrape` and the
-      // manga subcommand never sees it. That is why the subcommands here carry
-      // prefixed options -- csite and climit on `new`, and msite and mlimit on
-      // `manga` until this landed -- and why --file silently did nothing even
-      // after it was declared: declaring an option the parent already owns is
-      // not enough to win it.
-      //
-      // With positional options on, an option belongs to the command it follows.
-      // Prefixes stop being necessary and --file reaches the subcommand that
-      // declares it.
       enablePositionalOptions: true,
     },
   )
+
+  // The flag above is not sufficient on its own. nest-commander applies it to
+  // the commands it builds from decorators and never to the root program, but
+  // commander reads the setting from the root when it decides who owns an
+  // option -- so with only the flag set, `collect manga --headless` still gave
+  // --headless to `collect`, the subcommand saw headless: false, and puppeteer
+  // tried to open a real browser window on a machine with no display.
+  //
+  // The root is provided under a symbol nest-commander exports from its module
+  // but not from its index, hence the deeper import. If a future version starts
+  // configuring the root itself, this line becomes redundant rather than wrong.
+  app.get<Command>(Commander).enablePositionalOptions(true)
+
+  await CommandFactory.runApplication(app)
 
   // await CommandFactory.run(module, ['log', 'warn', 'error']);
 


### PR DESCRIPTION
**Follow-up to #23, which is broken on `main` without this.** Every spelling of the manga commands currently fails.

## What's wrong on main

`enablePositionalOptions: true` passed to `CommandFactory` is **inert**. nest-commander applies it only to the commands it builds from decorators ([`buildCommand`, command-runner.service.js:119](https://github.com/jmcdo29/nest-commander)) and never to the root program it parses with — and commander reads the setting from the root when deciding which command owns an option.

So #23 fixed nothing, while also removing `--msite`/`--mlimit`/`--mheadless`, which were the only spellings that worked. Net effect on `main` today:

| Command | Result |
|---|---|
| `collect manga --headless` | `--headless` goes to `collect`; subcommand sees `false` → tries to open a real browser |
| `scrape manga --headless` | same |
| `scrape manga --file urls.json` | `--file` goes to `scrape`; subcommand gets nothing |
| `scrape manga --mheadless` | `unknown option` — removed in #23 |

On a machine with no display that surfaces as:

```
Missing X server or $DISPLAY
The platform failed to initialize.  Exiting.
```

which is how it was found — on the scraper box, not in review.

## The fix

Set it on the root as well:

```ts
const app = await CommandFactory.createWithoutRunning(module, { …, enablePositionalOptions: true })
app.get<Command>(Commander).enablePositionalOptions(true)
await CommandFactory.runApplication(app)
```

`runWithoutClosing` is exactly `createWithoutRunning` + `runApplication`, so splitting it changes nothing else. The root is provided under a symbol nest-commander exports from its module but not its index, hence the deeper import — if a future version configures the root itself, this line becomes redundant rather than wrong.

## Verified

Against a real browser with `DISPLAY` unset, matching the scraper box, rather than a parser probe — a probe is what missed this, having set the flag on the root itself without noticing the framework doesn't:

```
collect manga --headless --pages 0   ->  "Collecting manga from 0 ranking pages"
collect manga --pages 0              ->  Failed to launch the browser process
```

`--pages 0` launches the browser then exits with nothing queued, so it tests the flag without crawling or writing.

Also confirmed `collect manga --site notasite` now reaches the subcommand's own validation instead of defaulting.

Builds clean, `tsc --noEmit` clean, 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)